### PR TITLE
Add points breakdown

### DIFF
--- a/espn_api/football/box_player.py
+++ b/espn_api/football/box_player.py
@@ -1,4 +1,4 @@
-from .constant import POSITION_MAP, PRO_TEAM_MAP
+from .constant import POSITION_MAP, PRO_TEAM_MAP, PLAYER_STATS_MAP
 from .player import Player
 from datetime import datetime, timedelta
 
@@ -30,9 +30,12 @@ class BoxPlayer(Player):
         for stats in player_stats:
             if stats['statSourceId'] == 0 and stats['scoringPeriodId'] == week:
                 self.points = round(stats['appliedTotal'], 2)
+                self.points_breakdown = {PLAYER_STATS_MAP.get(int(k), k):v for (k,v) in stats['appliedStats'].items()}
             elif stats['statSourceId'] == 1 and stats['scoringPeriodId'] == week:
                 self.projected_points = round(stats['appliedTotal'], 2)
-            
-    
+                self.projected_breakdown = {PLAYER_STATS_MAP.get(int(k), k):v for (k,v) in stats['appliedStats'].items()}
+
+
+
     def __repr__(self):
         return 'Player(%s, points:%d, projected:%d)' % (self.name, self.points, self.projected_points)

--- a/espn_api/football/box_score.py
+++ b/espn_api/football/box_score.py
@@ -17,3 +17,8 @@ class BoxScore(object):
             self.away_score =  round(data['away']['rosterForCurrentScoringPeriod']['appliedStatTotal'], 2)
             away_roster = data['away']['rosterForCurrentScoringPeriod']['entries']
             self.away_lineup = [BoxPlayer(player, pro_schedule, positional_rankings, week) for player in away_roster]
+
+    def __repr__(self):
+        away_team = self.away_team if self.away_team else "BYE"
+        home_team = self.home_team if self.home_team else "BYE"
+        return 'Box Score(%s at %s)' % (away_team, home_team)

--- a/espn_api/football/constant.py
+++ b/espn_api/football/constant.py
@@ -81,3 +81,77 @@ ACTIVITY_MAP = {
     'WAVIER': 180,
     'TRADED': 244
 }
+
+PLAYER_STATS_MAP = {
+    3: "passingYards",
+    4: "passingTouchdowns",
+
+    19: "passing2PtConversions",
+    20: "passingInterceptions",
+
+    24: "rushingYards",
+    25: "rushingTouchdowns",
+    26: "rushing2PtConversions",
+
+    42: "receivingYards",
+    43: "receivingTouchdowns",
+    44: "receiving2PtConversions",
+    53: "receivingReceptions",
+
+    72: "lostFumbles",
+
+    74: "madeFieldGoalsFrom50Plus",
+    77: "madeFieldGoalsFrom40To49",
+    80: "madeFieldGoalsFromUnder40",
+    85: "missedFieldGoals",
+    86: "madeExtraPoints",
+    88: "missedExtraPoints",
+
+    89:"defensive0PointsAllowed",
+    90: "defensive1To6PointsAllowed",
+    91: "defensive7To13PointsAllowed",
+    92: "defensive14To17PointsAllowed",
+
+    93: "defensiveBlockedKickForTouchdowns",
+    95: "defensiveInterceptions",
+    96: "defensiveFumbles",
+    97: "defensiveBlockedKicks",
+    98: "defensiveSafeties",
+    99: "defensiveSacks",
+
+    101: "kickoffReturnTouchdown",
+    102: "puntReturnTouchdown",
+    103: "fumbleReturnTouchdown",
+    104: "interceptionReturnTouchdown",
+
+    123: "defensive28To34PointsAllowed",
+    124: "defensive35To45PointsAllowed",
+
+    129: "defensive100To199YardsAllowed",
+    130: "defensive200To299YardsAllowed",
+    132: "defensive350To399YardsAllowed",
+    133: "defensive400To449YardsAllowed",
+    134: "defensive450To499YardsAllowed",
+    135: "defensive500To549YardsAllowed",
+    136: "defensiveOver550YardsAllowed",
+
+    # Punter Stats
+    140: "puntsInsideThe10", # PT10
+    141: "puntsInsideThe20", # PT20
+    148: "puntAverage44.0+", # PTA44
+    149: "puntAverage42.0-43.9", #PTA42
+    150: "puntAverage40.0-41.9", #PTA40
+
+    # Head Coach stats
+    161: "25+pointsWinMargin", #WM25
+    162: "20-24pointWinMargin", #WM20
+    163: "15-19pointWinMargin", #WM15
+    164: "10-14pointWinMargin", #WM10
+    165: "5-9pointWinMargin", # WM5
+    166: "1-4pointWinMargin", # WM1
+
+    155: "TeamWin", # TW
+
+    171: "20-24pointLossMargin", # LM20
+    172: "25+pointLossMargin", # LM25
+}


### PR DESCRIPTION
I found the codes for the points breakdown in this JS library ([repo](https://github.com/mkreiser/ESPN-Fantasy-Football-API),  [stat codes](https://github.com/mkreiser/ESPN-Fantasy-Football-API/blob/master/src/player-stats/player-stats.js)) and added them into the box player class. I think they are correct and seem to make sense for the various player/positions that I checked.

I manually added the Head Coach and Punter codes (my league has some wacky positions...)

also updated the `box_score.__repr__` to print out some useful info 

closes #80 