### PR TITLE
Refresh League without creating new object

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -43,6 +43,7 @@ class BaseLeague(ABC):
     
     def _fetch_teams(self, data, TeamClass):
         '''Fetch teams in league'''
+        self.teams = []
         teams = data['teams']
         members = data['members']
         schedule = data['schedule']

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -191,7 +191,7 @@ class League(BaseLeague):
         Should only be used with most recent season'''
         if self.year < 2019:
             raise Exception('Cant use box score before 2019')
-        if not week: # or week > self.current_week:
+        if not week or week > self.current_week:
             week = self.current_week
 
         params = {

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -84,6 +84,12 @@ class League(BaseLeague):
             positional_ratings[pos] = teams_rating
         return positional_ratings
 
+    def refresh(self):
+        '''Gets latest league data. This can be used instead of creating a new League class each week'''
+        data = super()._fetch_league()
+
+        self.nfl_week = data['status']['latestScoringPeriod']
+        self._fetch_teams(data)
     def load_roster_week(self, week: int) -> None:
         '''Sets Teams Roster for a Certain Week'''
         params = {
@@ -185,7 +191,7 @@ class League(BaseLeague):
         Should only be used with most recent season'''
         if self.year < 2019:
             raise Exception('Cant use box score before 2019')
-        if not week or week > self.current_week:
+        if not week: # or week > self.current_week:
             week = self.current_week
 
         params = {

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -45,7 +45,13 @@ class LeagueTest(TestCase):
         self.assertEqual(repr(league.settings), 'Settings(FXBG League)')
         self.assertEqual(league.current_week, 16)
         self.assertEqual(len(league.teams), 10)
-    
+
+        league.refresh()
+        self.assertEqual(repr(league), 'League(123, 2018)')
+        self.assertEqual(repr(league.settings), 'Settings(FXBG League)')
+        self.assertEqual(league.current_week, 16)
+        self.assertEqual(len(league.teams), 10)
+
     @requests_mock.Mocker()        
     def test_load_roster_week(self, m):
         self.mock_setUp(m)


### PR DESCRIPTION
Adds public function to get the latest league data (Team's roster, standings, settings, current week) without having to recreate the League Class #132 