### PR TITLE
Fix box_scores IndexError issue caused by rescheduled game

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -83,7 +83,7 @@ class BaseLeague(ABC):
         pro_team_schedule = {}
 
         for team in pro_teams:
-            if team['id'] != 0 and str(scoringPeriodId) in team['proGamesByScoringPeriod'].keys():
+            if team['id'] != 0 and (str(scoringPeriodId) in team['proGamesByScoringPeriod'].keys() and team['proGamesByScoringPeriod'][str(scoringPeriodId)]):
                 game_data = team['proGamesByScoringPeriod'][str(scoringPeriodId)][0]
                 pro_team_schedule[team['id']] = (game_data['homeProTeamId'], game_data['date'])  if team['id'] == game_data['awayProTeamId'] else (game_data['awayProTeamId'], game_data['date'])
         return pro_team_schedule


### PR DESCRIPTION
Adds a condition to check for scoring periods that have an empty list value when parsing the espn_request.get_pro_schedule() response #140