### PR TITLE
Add lineupSlot to basketball Player object

### DIFF
--- a/espn_api/basketball/constant.py
+++ b/espn_api/basketball/constant.py
@@ -115,10 +115,6 @@ STATS_MAP = {
     '44': '',
     '45': '',
     }
-    
-
-#ACTIVITY_MAP = {
-#}
 
 ACTIVITY_MAP = {
     178: 'FA ADDED',
@@ -131,4 +127,3 @@ ACTIVITY_MAP = {
     'WAIVER': 180,
     'TRADED': 244
 }
-

--- a/espn_api/basketball/player.py
+++ b/espn_api/basketball/player.py
@@ -8,6 +8,7 @@ class Player(object):
         self.name = json_parsing(data, 'fullName')
         self.playerId = json_parsing(data, 'id')
         self.position = POSITION_MAP[json_parsing(data, 'defaultPositionId') - 1]
+        self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId'), '')
         self.eligibleSlots = [POSITION_MAP[pos] for pos in json_parsing(data, 'eligibleSlots')]
         self.acquisitionType = json_parsing(data, 'acquisitionType')
         self.proTeam = PRO_TEAM_MAP[json_parsing(data, 'proTeamId')]
@@ -33,4 +34,3 @@ class Player(object):
             
     def __repr__(self):
         return 'Player(%s)' % (self.name, )
-        


### PR DESCRIPTION
The `lineupSlotId` field represents the slot in the team lineup that a player occupies during the current matchup. This information may be useful for optimizing lineups or predicting matchup outcomes.

I verified this change against my team in a private league, but I'm not sure if there are any other steps I should take—let me know if I missed anything 😄 

```python
>>> for player in my_team.roster:
...     print("{:>2} {}".format(player.lineupSlot, player.name))
... 
SG James Harden
IR Jimmy Butler
 C Nikola Vucevic
PG Kyle Lowry
 G D'Angelo Russell
UT Brook Lopez
PF Lauri Markkanen
UT Devonte' Graham
IR Kevin Love
BE Rui Hachimura
BE Darius Bazley
SF Keldon Johnson
 F Robert Covington
BE DeAndre Jordan
UT Delon Wright
```

<img width="300" alt="Screen Shot 2021-01-21 at 10 21 32 PM" src="https://user-images.githubusercontent.com/12125433/105454623-09110880-5c37-11eb-96eb-8eec59c04fd7.png">