### PR TITLE
Add option to get league data from a specific scoring period

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -7,7 +7,7 @@ from .requests.espn_requests import EspnFantasyRequests
 
 class BaseLeague(ABC):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, sport: str, espn_s2=None, swid=None, username=None, password=None, debug=False):
+    def __init__(self, league_id: int, year: int, sport: str, scoring_period: int = None, espn_s2=None, swid=None, username=None, password=None, debug=False):
         self.logger = Logger(name=f'{sport} league', debug=debug)
         self.league_id = league_id
         self.year = year
@@ -21,7 +21,7 @@ class BaseLeague(ABC):
                 'espn_s2': espn_s2,
                 'SWID': swid
             }
-        self.espn_request = EspnFantasyRequests(sport=sport, year=year, league_id=league_id, cookies=cookies, logger=self.logger)
+        self.espn_request = EspnFantasyRequests(sport=sport, year=year, league_id=league_id, scoring_period=scoring_period, cookies=cookies, logger=self.logger)
         if username and password:
             self.espn_request.authentication(username, password)
 

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -9,13 +9,13 @@ from .team import Team
 from .player import Player
 from .matchup import Matchup
 from .constant import PRO_TEAM_MAP
-from.activity import Activity
+from .activity import Activity
 from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
-        super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
+    def __init__(self, league_id: int, year: int, scoring_period: int = None, espn_s2=None, swid=None, username=None, password=None, debug=False):
+        super().__init__(league_id=league_id, year=year, sport='nba', scoring_period=scoring_period, espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
             
         data = self._fetch_league()
         self._fetch_teams(data)

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -16,8 +16,8 @@ from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
-        super().__init__(league_id=league_id, year=year, sport='nfl', espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
+    def __init__(self, league_id: int, year: int, scoring_period: int = None, espn_s2=None, swid=None, username=None, password=None, debug=False):
+        super().__init__(league_id=league_id, year=year, sport='nfl', scoring_period=scoring_period, espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
         self._fetch_league()
 
     def _fetch_league(self):

--- a/espn_api/requests/espn_requests.py
+++ b/espn_api/requests/espn_requests.py
@@ -16,11 +16,12 @@ def checkRequestStatus(status: int) -> None:
         raise Exception('Unknown %s Error' % status)
 
 class EspnFantasyRequests(object):
-    def __init__(self, sport: str, year: int, league_id: int, cookies: dict = None, logger: Logger = None):
+    def __init__(self, sport: str, year: int, league_id: int, scoring_period: int = None, cookies: dict = None, logger: Logger = None):
         if sport not in FANTASY_SPORTS:
             raise Exception(f'Unknown sport: {sport}, available options are {FANTASY_SPORTS.keys()}')
         self.year = year
         self.league_id = league_id
+        self.scoring_period = scoring_period
         self.ENDPOINT = FANTASY_BASE_ENDPOINT + FANTASY_SPORTS[sport] + '/seasons/' +  str(self.year)
         self.cookies = cookies
         self.logger = logger
@@ -56,6 +57,8 @@ class EspnFantasyRequests(object):
         params = {
             'view': ['mTeam', 'mRoster', 'mMatchup', 'mSettings'] 
         }
+        if self.scoring_period is not None:
+            params['scoringPeriodId'] = self.scoring_period
         data = self.league_get(params=params)
         return data
     

--- a/tests/basketball/integration/test_league.py
+++ b/tests/basketball/integration/test_league.py
@@ -9,6 +9,11 @@ class LeagueTest(TestCase):
 
         self.assertEqual(league.scoringPeriodId, 178)
 
+    def test_league_init_scoring_period(self):
+        league = League(411647, 2019, scoring_period=168)
+
+        self.assertEqual(league.scoringPeriodId, 168)
+
     def test_league_scoreboard(self):
         league = League(411647, 2019)
         scores = league.scoreboard()
@@ -26,6 +31,11 @@ class LeagueTest(TestCase):
         league = League(411647, 2017)
         
         self.assertEqual(league.scoringPeriodId, 170)
+
+    def test_past_league_scoring_period(self):
+        league = League(411647, 2017, scoring_period=168)
+
+        self.assertEqual(league.scoringPeriodId, 168)
 
     def test_past_league_scoreboard(self):
         league = League(411647, 2017)

--- a/tests/football/integration/test_league.py
+++ b/tests/football/integration/test_league.py
@@ -7,11 +7,27 @@ class LeagueTest(TestCase):
     def test_league_init(self):
         league = League(1234, 2018)
 
+        self.assertEqual(league.scoringPeriodId, 18)
         self.assertEqual(league.current_week, 17)
+
+    def test_league_init_scoring_period(self):
+        league = League(1234, 2018, scoring_period=16)
+
+        self.assertEqual(league.scoringPeriodId, 16)
+        self.assertEqual(league.current_week, 16)
 
     def test_past_league(self):
         league = League(12345, 2017)
 
+        self.assertEqual(league.scoringPeriodId, 17)
+        self.assertEqual(league.current_week, 17)
+        self.assertEqual(league.nfl_week, 18)
+
+    def test_past_league_scoring_period(self):
+        league = League(12345, 2017, scoring_period=16)
+
+        self.assertEqual(league.scoringPeriodId, 16)
+        self.assertEqual(league.current_week, 16)
         self.assertEqual(league.nfl_week, 18)
 
     def test_private_league(self):


### PR DESCRIPTION
Right now it is only possible to get league data from the current scoring period. However, teams can make transactions (add, drop, trade, IR, set lineup) that affect future scoring periods. It may also be useful to look back at the state of a team in previous scoring periods.

With these changes, you can now specify the scoring period from which you want to get league data. As far as I can tell, the only data affected are the `Team.roster` and `Player.lineupSlot` fields.