### PR TITLE
Basketball Box Score

### DIFF
--- a/espn_api/basketball/box_player.py
+++ b/espn_api/basketball/box_player.py
@@ -1,0 +1,35 @@
+from .constant import POSITION_MAP, PRO_TEAM_MAP, STATS_MAP
+from .player import Player
+from datetime import datetime, timedelta
+
+class BoxPlayer(Player):
+    '''player with extra data from a matchup'''
+    def __init__(self, data, pro_schedule):
+        super(BoxPlayer, self).__init__(data)
+        self.slot_position = 'FA'
+        self.pro_opponent = "None" # professional team playing against
+        self.game_played = 100 # 0-100 for percent of game played
+        self.points = 0
+        self.points_breakdown = {}
+
+        if 'lineupSlotId' in data:
+            self.slot_position = POSITION_MAP[data['lineupSlotId']]
+
+        player = data['playerPoolEntry']['player'] if 'playerPoolEntry' in data else data['player']
+        if player['proTeamId'] in pro_schedule:
+            (opp_id, date) = pro_schedule[player['proTeamId']]
+            self.game_played = 100 if datetime.now() > datetime.fromtimestamp(date/1000.0) + timedelta(hours=3) else 0
+            self.pro_opponent = PRO_TEAM_MAP[opp_id]
+                
+        player_stats = player.get('stats', [])
+        for stats in player_stats:
+            stats_breakdown = stats.get('appliedStats') if stats.get('appliedStats') else stats.get('stats', {})
+            breakdown = {STATS_MAP.get(k, k):v for (k,v) in stats_breakdown.items()}
+            points = round(stats.get('appliedTotal', 0), 2)
+            self.points = points
+            self.points_breakdown = breakdown
+
+
+
+    def __repr__(self):
+        return 'Player(%s, points:%d)' % (self.name, self.points)

--- a/espn_api/basketball/box_score.py
+++ b/espn_api/basketball/box_score.py
@@ -1,0 +1,36 @@
+from .box_player import BoxPlayer
+
+class BoxScore(object):
+    ''' '''
+    def __init__(self, data, pro_schedule, by_matchup):
+        self.winner = data['winner']
+        self.home_team = data['home']['teamId']
+        self.home_projected = -1 # week is over/not set
+        roster_key = 'rosterForMatchupPeriod' if by_matchup else 'rosterForCurrentScoringPeriod'
+        home_roster =  data['home'].get(roster_key, {})
+        if 'totalPointsLive' in data['home']:
+          self.home_score = round(data['home']['totalPointsLive'], 2)
+          self.home_projected = round(data['home'].get('totalProjectedPointsLive', -1), 2)
+        else:
+          self.home_score = round(home_roster.get('appliedStatTotal', 0), 2)
+        self.home_lineup = [BoxPlayer(player, pro_schedule) for player in home_roster.get('entries', [])]
+
+        # For Leagues with bye weeks
+        self.away_team = 0
+        self.away_score = 0
+        self.away_lineup = []
+        self.away_projected = -1 # week is over/not set
+        if 'away' in data:
+          self.away_team = data['away']['teamId']
+          away_roster = data['away'].get(roster_key, {})
+          if 'totalPointsLive' in data['away']:
+            self.away_score = round(data['away']['totalPointsLive'], 2)
+            self.away_projected = round(data['away'].get('totalProjectedPointsLive', -1), 2)
+          else:
+            self.away_score = round(away_roster.get('appliedStatTotal', 0), 2)
+          self.away_lineup = [BoxPlayer(player, pro_schedule) for player in away_roster.get('entries', [])]
+
+    def __repr__(self):
+        away_team = self.away_team if self.away_team else "BYE"
+        home_team = self.home_team if self.home_team else "BYE"
+        return 'Box Score(%s at %s)' % (away_team, home_team)

--- a/tests/basketball/integration/test_league.py
+++ b/tests/basketball/integration/test_league.py
@@ -22,6 +22,22 @@ class LeagueTest(TestCase):
 
         self.assertNotEqual(len(free_agents), 0)
 
+    def test_league_box_scores(self):
+        league = League(411647, 2019)
+        final_matchup = league.box_scores()[0]
+        middle_matchup = league.box_scores(matchup_period=7)[0]
+        # same matchup period but single scoring period
+        scoring_period_matchup = league.box_scores(scoring_period=48)[0]
+
+        self.assertEqual(final_matchup.home_score, 4240.0)
+        self.assertEqual(final_matchup.away_lineup[0].points, 156.0)
+
+        self.assertEqual(middle_matchup.home_score, 1234.0)
+        self.assertEqual(middle_matchup.away_lineup[0].points, 12.5)
+
+        self.assertEqual(scoring_period_matchup.home_score, 234.0)
+        self.assertEqual(scoring_period_matchup.away_lineup[0].points, 0)
+
     def test_past_league(self):
         league = League(411647, 2017)
         


### PR DESCRIPTION
New `box_score` interface that takes two optional parameters `matchup_period` and `scoring_period`.

If `matchup_period` is passed: It will return the Box Score Class with the total points and total player points for that whole matchup across multiple games.

If `scoring_period` is passed: It will return the Box Score Class for that scoring period (usually a single day) and the points and player points will reflect that single scoring period.

If none of the parameters are passed: It will return the Box Score Class for the current matchup and scoring period with total points and player points up to the scoring period.
