### PR TITLE
Baseball: add getting box scores for categories

### DIFF
--- a/espn_api/baseball/box_score.py
+++ b/espn_api/baseball/box_score.py
@@ -1,0 +1,52 @@
+from .constant import STATS_MAP
+
+class BoxScore(object):
+    ''' '''
+    def __init__(self, data):
+        self.winner = data['winner']
+        
+        home_team = self._process_team(data['home'])
+
+        self.home_team = home_team['id']
+        self.home_wins = home_team['wins']
+        self.home_losses = home_team['losses']
+        self.home_ties = home_team['ties']
+        self.home_stats = home_team['stats']
+
+        if 'away' in data:
+            away_team = self._process_team(data['away'])
+
+            self.away_team = away_team['id']
+            self.away_wins = away_team['wins']
+            self.away_losses = away_team['losses']
+            self.away_ties = away_team['ties']
+            self.away_stats = away_team['stats']
+        else:
+            self.away_team = None
+            self.away_wins = None
+            self.away_losses = None
+            self.away_ties = None
+            self.away_stats = None
+    
+    @staticmethod
+    def _process_team(team_data):
+        team = {}
+
+        team['id'] = team_data['teamId']
+        team['wins'] = team_data['cumulativeScore']['wins']
+        team['losses'] = team_data['cumulativeScore']['losses']
+        team['ties'] = team_data['cumulativeScore']['ties']
+
+        team['stats'] = {}
+        for stat_key, stat_dict in team_data['cumulativeScore']['scoreByStat'].items():
+            team['stats'][STATS_MAP[int(stat_key)]] = {
+                'value': stat_dict['score'],
+                'result': stat_dict['result']
+            }
+        
+        return team
+
+    def __repr__(self):
+        away_team = self.away_team if self.away_team else "BYE"
+        home_team = self.home_team if self.home_team else "BYE"
+        return 'Box Score(%s at %s)' % (away_team, home_team)

--- a/espn_api/baseball/box_score.py
+++ b/espn_api/baseball/box_score.py
@@ -33,6 +33,7 @@ class BoxScore(ABC):
 
 
 class H2HCategoryBoxScore(BoxScore):
+    '''Boxscore class for head to head categories leagues'''
     def __init__(self, data):
         super().__init__(data)
 
@@ -63,3 +64,13 @@ class H2HCategoryBoxScore(BoxScore):
             self.away_losses = team.get('losses')
             self.away_ties = team.get('ties')
             self.away_stats = team.get('stats')
+
+
+class H2HPointsBoxScore(BoxScore):
+    '''Boxscore class for head to head points leagues'''
+    def __init__(self, data):
+        super().__init__(data)
+
+    def _process_team(self, team_data, is_home_team):
+        super()._process_team(team_data, is_home_team)
+        # TODO implement setting the scores

--- a/espn_api/baseball/box_score.py
+++ b/espn_api/baseball/box_score.py
@@ -1,52 +1,65 @@
+from abc import ABC, abstractmethod
+
 from .constant import STATS_MAP
 
-class BoxScore(object):
+class BoxScore(ABC):
     ''' '''
     def __init__(self, data):
         self.winner = data['winner']
         
-        home_team = self._process_team(data['home'])
-
-        self.home_team = home_team['id']
-        self.home_wins = home_team['wins']
-        self.home_losses = home_team['losses']
-        self.home_ties = home_team['ties']
-        self.home_stats = home_team['stats']
+        self._process_team(data['home'], True)
 
         if 'away' in data:
-            away_team = self._process_team(data['away'])
-
-            self.away_team = away_team['id']
-            self.away_wins = away_team['wins']
-            self.away_losses = away_team['losses']
-            self.away_ties = away_team['ties']
-            self.away_stats = away_team['stats']
+            self._process_team(data['away'], False)
         else:
-            self.away_team = None
-            self.away_wins = None
-            self.away_losses = None
-            self.away_ties = None
-            self.away_stats = None
-    
-    @staticmethod
-    def _process_team(team_data):
+            self._process_team(None, False)
+
+    @abstractmethod
+    def _process_team(self, team_data, is_home_team):
         team = {}
 
-        team['id'] = team_data['teamId']
-        team['wins'] = team_data['cumulativeScore']['wins']
-        team['losses'] = team_data['cumulativeScore']['losses']
-        team['ties'] = team_data['cumulativeScore']['ties']
+        if team_data is not None:
+            team['id'] = team_data['teamId']
 
-        team['stats'] = {}
-        for stat_key, stat_dict in team_data['cumulativeScore']['scoreByStat'].items():
-            team['stats'][STATS_MAP[int(stat_key)]] = {
-                'value': stat_dict['score'],
-                'result': stat_dict['result']
-            }
-        
-        return team
-
+        if is_home_team:
+            self.home_team = team['id']
+        else:
+            self.away_team = team.get('id')
+    
     def __repr__(self):
         away_team = self.away_team if self.away_team else "BYE"
         home_team = self.home_team if self.home_team else "BYE"
         return 'Box Score(%s at %s)' % (away_team, home_team)
+
+
+class H2HCategoryBoxScore(BoxScore):
+    def __init__(self, data):
+        super().__init__(data)
+
+    def _process_team(self, team_data, is_home_team):
+        super()._process_team(team_data, is_home_team)
+
+        team = {}
+
+        if team_data is not None:
+            team['wins'] = team_data['cumulativeScore']['wins']
+            team['losses'] = team_data['cumulativeScore']['losses']
+            team['ties'] = team_data['cumulativeScore']['ties']
+
+            team['stats'] = {}
+            for stat_key, stat_dict in team_data['cumulativeScore']['scoreByStat'].items():
+                team['stats'][STATS_MAP[int(stat_key)]] = {
+                    'value': stat_dict['score'],
+                    'result': stat_dict['result']
+                }
+        
+        if is_home_team:
+            self.home_wins = team['wins']
+            self.home_losses = team['losses']
+            self.home_ties = team['ties']
+            self.home_stats = team['stats']
+        else:
+            self.away_wins = team.get('wins')
+            self.away_losses = team.get('losses')
+            self.away_ties = team.get('ties')
+            self.away_stats = team.get('stats')

--- a/espn_api/baseball/constant.py
+++ b/espn_api/baseball/constant.py
@@ -8,7 +8,7 @@ POSITION_MAP = {
     6: '2B/SS',
     7: '1B/3B',
     8: 'LF',
-    9: 'CF', # For unknown use stat number
+    9: 'CF',
     10: 'RF',
     11: 'DH',
     12: 'UTIL',
@@ -57,6 +57,10 @@ PRO_TEAM_MAP = {
     30: 'TB',
 }
 
+# where batter and pitcher stats have the same abbreviation and both are commonly used
+# B_ = batter stat
+# P_ = pitcher stat
+
 STATS_MAP = {
     0: 'AB',
     1: 'H',
@@ -66,62 +70,62 @@ STATS_MAP = {
     5: 'HR',
     6: 'XBH', # 2B + 3B + HR
     7: '1B',
-    8: 'TB', # 1 * COUNT(1B) + 2 * COUNT(2B) + 3 * COUNT(3B) + 4 * COUNT(4B)
+    8: 'TB', # 1 * COUNT(1B) + 2 * COUNT(2B) + 3 * COUNT(3B) + 4 * COUNT(HR)
     9: 'SLG',
-    10: 'BB',
+    10: 'B_BB',
     11: 'B_IBB',
     12: 'HBP',
     13: 'SF', # Sacrifice Fly
     14: 'SH', # Sacrifice Hit - i.e. Sacrifice Bunt
-    15: 'SAC', # Total Sacrifices = SF + SH
+    15: 'SAC', # total sacrifices = SF + SH
     16: 'PA',
-    17: 'B_OBP',
+    17: 'OBP',
     18: 'OPS', # OBP + SLG
-    19: 'RC', # Runs Created =  TB * (H + BB) / (AB + BB)
+    19: 'RC', # Runs Created = TB * (H + BB) / (AB + BB)
     20: 'R',
     21: 'RBI',
     # 22: '',
     23: 'SB',
     24: 'CS',
-    25: 'SB-CS', # Not sure what this is called / how to abbreviate
+    25: 'SB-CS', # net steals
     26: 'GDP',
     27: 'B_SO', # batter strike-outs
     28: 'PS', # pitches seen
     29: 'PPA', # pitches per plate appearance = PS / PA
     # 30: '',
     31: 'CYC',
-    32: 'P_G', # pitcher Games pitched
+    32: 'GP', # pitcher games pitched
     33: 'GS', # games started
-    34: 'OUTS',
-    35: 'BATTERS',
-    36: 'PITCHES',
+    34: 'OUTS',  # divide by 3 for IP
+    35: 'TBF',
+    36: 'P',  # pitches
     37: 'P_H',
-    38: 'BAA', # Batting average against
+    38: 'OBA', # Opponent Batting Average
     39: 'P_BB',
-    40: 'P_IBB', # Intentional Walks given
+    40: 'P_IBB', # intentional walks allowed
     41: 'WHIP',
     42: 'HBP',
-    43: 'P_OBP', # On-base percentage against
+    43: 'OOBP', # Opponent On-Base Percentage
     44: 'P_R',
     45: 'ER',
     46: 'P_HR',
     47: 'ERA',
     48: 'K',
-    49: 'K9',
+    49: 'K/9',
     50: 'WP',
-    51: 'BALK',
+    51: 'BLK',
     52: 'PK', # pickoff
-    53: 'QS',
+    53: 'W',
     54: 'L',
     55: 'WPCT', # Win Percentage
     56: 'SVO', # Save opportunity
     57: 'SV',
-    58: 'BS', # Blown Save
+    58: 'BLSV', # BLown SaVe
     59: 'SV%', # Save percentage
-    60: 'HD',
+    60: 'HLD',
     # 61: '',
     62: 'CG',
-    63: 'W',
+    # 63: '',
     # 64: '',
     65: 'NH', # No-hitters
     66: 'PG', # Perfect Games
@@ -144,7 +148,7 @@ STATS_MAP = {
     # 79: ,
     # 80: ,
     81: 'G', # Games Played
-    82: 'KBB', # Strikeout to Walk Ratio
+    82: 'K/BB', # Strikeout to Walk Ratio
     99: 'STARTER',
 }
 

--- a/espn_api/baseball/league.py
+++ b/espn_api/baseball/league.py
@@ -9,7 +9,7 @@ from ..base_league import BaseLeague
 from .team import Team
 from .player import Player
 from .matchup import Matchup
-from .box_score import BoxScore, H2HCategoryBoxScore
+from .box_score import BoxScore, H2HCategoryBoxScore, H2HPointsBoxScore
 from.activity import Activity
 from .constant import POSITION_MAP, ACTIVITY_MAP
 
@@ -23,6 +23,8 @@ class League(BaseLeague):
 
         if self.scoring_type == 'H2H_CATEGORY':
             self._box_score_class = H2HCategoryBoxScore
+        elif self.scoring_type == 'H2H_POINTS':
+            self._box_score_class = H2HPointsBoxScore
         else:
             self._box_score_class = BoxScore
 

--- a/tests/baseball/integration/test_league.py
+++ b/tests/baseball/integration/test_league.py
@@ -3,11 +3,11 @@ from espn_api.baseball import League
 
 # Integration test to make sure ESPN's API didnt change
 class LeagueTest(TestCase):
+    def setUp(self):
+        self.league = League(81134470, 2021)
     
     def test_league_init(self):
-        league = League(81134470, 2021)
-
-        self.assertEqual(len(league.teams), 8)
+        self.assertEqual(len(self.league.teams), 8)
 
    #  def test_league_scoreboard(self):
    #      league = League(81134470, 2021)
@@ -17,7 +17,11 @@ class LeagueTest(TestCase):
    #      self.assertEqual(scores[0].away_final_score, 2965.0)
     
     def test_league_free_agents(self):
-        league = League(81134470, 2021)
-        free_agents = league.free_agents()
+        free_agents = self.league.free_agents()
 
         self.assertNotEqual(len(free_agents), 0)
+    
+    def test_league_box_scores(self):
+        box_scores = self.league.box_scores(1)
+
+        self.assertNotEqual(len(box_scores), 0)


### PR DESCRIPTION
I added retrieving box scores for baseball leagues that are head to head categories.

I also cleaned up some of the stat mappings (names and also the comments about them). I used the stats abbreviations from the glossary at the bottom of ESPN stat pages (see https://www.espn.com/mlb/player/stats/_/id/28976/max-scherzer for example).

The only semantic change is for stat `53` which was marked as `QS` (quality starts) but I am certain is `W` (wins), based on examining the box scores from my own league. I removed `63` which was previously `W`.