### PR TITLE
Baseball: ignore unknown player positions

### DIFF
--- a/espn_api/baseball/constant.py
+++ b/espn_api/baseball/constant.py
@@ -17,10 +17,9 @@ POSITION_MAP = {
     15: 'RP',
     16: 'BE',
     17: 'IL',
-    18: '18',
     19: 'IF', # 1B/2B/SS/3B
-    22: '22', # Josh Fleming (2020)
     # reverse TODO
+    # 18, 21, 22 have appeared but unknown what position they correspond to
 }
 
 PRO_TEAM_MAP = {

--- a/espn_api/baseball/player.py
+++ b/espn_api/baseball/player.py
@@ -9,7 +9,7 @@ class Player(object):
         self.playerId = json_parsing(data, 'id')
         self.position = POSITION_MAP[json_parsing(data, 'defaultPositionId') - 1]
         self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId'), '')
-        self.eligibleSlots = [POSITION_MAP[pos] for pos in json_parsing(data, 'eligibleSlots')]
+        self.eligibleSlots = [POSITION_MAP.get(pos, pos) for pos in json_parsing(data, 'eligibleSlots')]  # if position isn't in position map, just use the position id number
         self.acquisitionType = json_parsing(data, 'acquisitionType')
         self.proTeam = PRO_TEAM_MAP[json_parsing(data, 'proTeamId')]
         self.injuryStatus = json_parsing(data, 'injuryStatus')


### PR DESCRIPTION
I found a few players that had a position id of 21 in their `eligibleSlots`. They were all players in the minor leagues, almost entire players drafter last year. I don't know what 21 could possibly correspond to, so it seems like a more general solution to allow the position id to pass through without translation if it's not in the mapping. The existing `POSITION_MAP` mapping seems complete to me so I don't think we're really missing anything by not mapping 18, 21, or 22.

Examples of players with an `eligibleSlots` of 21 are Austin Hendrick, Luis Matos, Blaze Jordan, and Carlos Colmenarez.