### PR TITLE
Added League Function to get All Players

### DIFF
--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -108,12 +108,15 @@ class League(BaseLeague):
 
         return activity
 
-    def free_agents(self, week: int=None, size: int=50, position: str=None, position_id: int=None) -> List[Player]:
-        '''Returns a List of Free Agents for a Given Week\n
+    def players(self, week: int=None, size: int=50, position: str=None, position_id: int=None, types: list=[]) -> List[Player]:
+        '''Returns a List of Players\n
         Should only be used with most recent season'''
 
         if self.year < 2019:
             raise Exception('Cant use free agents before 2019')
+        for type in types:
+            if not type in {"FREEAGENT", "WAIVERS", "ONTEAM"}:
+                raise Exception('Invalid type: {}'.format(type))
         if not week:
             week = self.current_week
         
@@ -128,7 +131,7 @@ class League(BaseLeague):
             'view': 'kona_player_info',
             'scoringPeriodId': week,
         }
-        filters = {"players":{"filterStatus":{"value":["FREEAGENT","WAIVERS"]},"filterSlotIds":{"value":slot_filter},"limit":size,"sortPercOwned":{"sortPriority":1,"sortAsc":False},"sortDraftRanks":{"sortPriority":100,"sortAsc":True,"value":"STANDARD"}}}
+        filters = {"players":{"filterStatus":{"value":types},"filterSlotIds":{"value":slot_filter},"limit":size,"sortPercOwned":{"sortPriority":1,"sortAsc":False},"sortDraftRanks":{"sortPriority":100,"sortAsc":True,"value":"STANDARD"}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
 
         data = self.espn_request.league_get(params=params, headers=headers)

--- a/tests/basketball/integration/test_league.py
+++ b/tests/basketball/integration/test_league.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import unittest
 from espn_api.basketball import League
 
 # Integration test to make sure ESPN's API didn't change
@@ -16,11 +17,23 @@ class LeagueTest(TestCase):
         self.assertEqual(scores[0].home_final_score, 4240.0)
         self.assertEqual(scores[0].away_final_score, 2965.0)
     
-    def test_league_free_agents(self):
+    def test_league_players(self):
         league = League(411647, 2019)
-        free_agents = league.free_agents()
+        # set size=1000 to get all players (doesn't have to be 1000, just needs to be large)
+        free_agents = league.players(size=1000, types=["FREEAGENT"])
+        waivers = league.players(size=1000, types=["WAIVERS"])
+        on_team = league.players(size=1000, types=["ONTEAM"])
+        all1 = league.players(size=1000, types=["FREEAGENT", "WAIVERS", "ONTEAM"])
+        all2 = league.players(size=1000)
 
         self.assertNotEqual(len(free_agents), 0)
+        
+        self.assertNotEqual(len(on_team), 0)
+        
+        self.assertEqual(len(all1), len(all2))
+        self.assertNotEqual(len(all2), 0)
+        
+        self.assertEqual(len(free_agents)+len(waivers)+len(on_team), len(all2))
 
     def test_league_box_scores(self):
         league = League(411647, 2019)


### PR DESCRIPTION
- Changed the `free_agents()` function to a more general `player()` option that accepts a new parameter `type` to define what kind of players a user wants to fetch (i.e. "FREEAGENT", "WAIVERS", "ONTEAM")
- New tests added for `player()` function

**Note**: I noticed that when creating the `Player()` object, it omits the `onTeamId`. It may be useful to retain that information so that one could go from `Player` to `Team`.