### PR TITLE
add default for hockey league data['schedule']['home']

### DIFF
--- a/espn_api/hockey/league.py
+++ b/espn_api/hockey/league.py
@@ -33,7 +33,7 @@ class League(BaseLeague):
         self.matchup_ids = {}
         for match in schedule:
             matchup_period = match.get('matchupPeriodId')
-            scoring_periods = match['home'].get('pointsByScoringPeriod', {}).keys()
+            scoring_periods = match.get('home', {}).get('pointsByScoringPeriod', {}).keys()
             if len(scoring_periods) > 0:
                 if matchup_period not in self.matchup_ids:
                     self.matchup_ids[matchup_period] = sorted(scoring_periods)


### PR DESCRIPTION
I was getting the following error when doing `league = League(league_id=LEAGUE_ID, year=2022, swid=SWID, espn_s2=ESPN_S2, debug=True)`

```
Traceback (most recent call last):
  File "main.py", line 11, in <module>
    f()
  File ".../espn-api/main.py", line 7, in f
    league = League(league_id=LEAGUE_ID, year=2022, swid=SWID, espn_s2=ESPN_S2, debug=True)
  File ".../espn-api/espn_apii/hockey/league.py", line 22, in __init__
    data = self._fetch_league()
  File ".../espn-api/espn_api/hockey/league.py", line 30, in _fetch_league
    self._map_matchup_ids(data['schedule'])
  File ".../espn-api/espn_api/hockey/league.py", line 39, in _map_matchup_ids
    scoring_periods = match['home'].get('pointsByScoringPeriod', {}).keys()
KeyError: 'home'
```

I noticed that the code for basketball leagues was doing `match.get('home', {})` instead of `match['home']`, so i figured the same thing needed to happen here for hockey.