### PR TITLE
Add matchup type and is playoff

### DIFF
--- a/espn_api/football/box_score.py
+++ b/espn_api/football/box_score.py
@@ -3,6 +3,9 @@ from .box_player import BoxPlayer
 class BoxScore(object):
     ''' '''
     def __init__(self, data, pro_schedule, positional_rankings, week, year):
+        self.matchup_type = data.get('playoffTierType', 'NONE') 
+        self.is_playoff = self.matchup_type != 'None'
+        
         self.home_team = data['home']['teamId']
         self.home_projected = -1 # week is over/not set
         if 'totalPointsLive' in data['home']:

--- a/espn_api/football/matchup.py
+++ b/espn_api/football/matchup.py
@@ -11,6 +11,8 @@ class Matchup(object):
         '''Fetch info for matchup'''
         self.home_team = self.data['home']['teamId']
         self.home_score = self.data['home']['totalPoints']
+        self.matchup_type = self.data.get('playoffTierType', 'NONE')
+        self.is_playoff = self.matchup_type != 'None'
 
         # For Leagues with bye weeks
         self.away_team = 0


### PR DESCRIPTION
`is_playoff` flag and `matchup_type` is added to box score and matchup classes. `matchup_type` will be set to `NONE` for regular games and then for playoffs it can be `WINNERS_BRACKET` `LOSERS_CONSOLATION_LADDER` `WINNERS_CONSOLATION_LADDER` and `LOSERS_CONSOLATION_LADDER`. There could possibly be more as these are the only ones I see in one of my leagues data.

#337 