### PR TITLE
Add __init__ parameter to allow leagues to skip the data fetching.

### DIFF
--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -16,9 +16,13 @@ from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
+    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
-            
+        
+        if fetch_league:
+            self.fetch_league()
+
+    def fetch_league(self):
         data = self._fetch_league()
         self._fetch_teams(data)
 

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -16,8 +16,13 @@ from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
+    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nfl', espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
+        
+        if fetch_league:
+            self.fetch_league()
+
+    def fetch_league(self):
         self._fetch_league()
 
     def _fetch_league(self):

--- a/espn_api/hockey/league.py
+++ b/espn_api/hockey/league.py
@@ -14,10 +14,14 @@ from ..base_league import BaseLeague
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
 
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
+    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nhl', espn_s2=espn_s2, swid=swid, username=username,
                          password=password, debug=debug)
 
+        if fetch_league:
+            self.fetch_league()
+
+    def fetch_league(self):
         data = self._fetch_league()
         self._fetch_teams(data)
 

--- a/espn_api/wbasketball/league.py
+++ b/espn_api/wbasketball/league.py
@@ -15,9 +15,13 @@ from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, debug=False):
+    def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, username=None, password=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='wnba', espn_s2=espn_s2, swid=swid, username=username, password=password, debug=debug)
-            
+        
+        if fetch_league:
+            self._fetch_league()
+        
+    def fetch_league(self):
         data = self._fetch_league()
         self._fetch_teams(data)
 

--- a/tests/baseball/integration/test_league.py
+++ b/tests/baseball/integration/test_league.py
@@ -5,6 +5,7 @@ from espn_api.baseball import League
 class LeagueTest(TestCase):
     def setUp(self):
         self.league = League(81134470, 2021)
+        self.blank_league = League(81134470, 2021, fetch_league=False)
     
     def test_league_init(self):
         self.assertEqual(len(self.league.teams), 8)
@@ -25,3 +26,6 @@ class LeagueTest(TestCase):
         box_scores = self.league.box_scores(1)
 
         self.assertNotEqual(len(box_scores), 0)
+
+    def test_blank_league_init(self):
+        self.assertEqual(len(self.blank_league.teams), 0)

--- a/tests/basketball/integration/test_league.py
+++ b/tests/basketball/integration/test_league.py
@@ -49,3 +49,7 @@ class LeagueTest(TestCase):
 
         self.assertTrue(scores[0].home_final_score > 0)
         self.assertTrue(scores[0].away_final_score > 0)
+    
+    def test_blank_league_init(self):
+        blank_league = League(411647, 2019, fetch_league=False)
+        self.assertEqual(len(blank_league.teams), 0)

--- a/tests/football/integration/test_league.py
+++ b/tests/football/integration/test_league.py
@@ -55,3 +55,7 @@ class LeagueTest(TestCase):
         self.assertEqual(len(players), 2)
         self.assertEqual(players[0].name, 'Patrick Mahomes')
         self.assertEqual(players[1].name, 'Austin Ekeler')
+
+    def test_blank_league_init(self):
+        blank_league = League(48153503, 2019, fetch_league=False)
+        self.assertEqual(len(blank_league.teams), 0)

--- a/tests/hockey/integration/test_league.py
+++ b/tests/hockey/integration/test_league.py
@@ -12,3 +12,6 @@ class LeagueTest(TestCase):
         self.assertEqual(league.start_date.month, 1)
         self.assertEqual(league.start_date.day, 13)
 
+    def test_blank_league_init(self):
+        blank_league = League(77421173, 2021, fetch_league=False)
+        self.assertEqual(len(blank_league.teams), 0)

--- a/tests/wbasketball/integration/test_league.py
+++ b/tests/wbasketball/integration/test_league.py
@@ -49,3 +49,7 @@ class LeagueTest(TestCase):
 
     #     self.assertTrue(scores[0].home_final_score > 0)
     #     self.assertTrue(scores[0].away_final_score > 0)
+    
+    def test_blank_league_init(self):
+        blank_league = League(1010650954, 2022, fetch_league=False)
+        self.assertEqual(len(blank_league.teams), 0)


### PR DESCRIPTION
** Parameter "fetch_league" defaults to True but when a user selects or passes
False the data fetching will be handled later.

** Added a public "fetch_league" function to handle the explicit data fetching and expose the function to users. This does not appear in the base class

** Added tests for the init of the leagues without fetching data.

#338 