### PR TITLE
add faab to league settings

### DIFF
--- a/espn_api/base_settings.py
+++ b/espn_api/base_settings.py
@@ -14,6 +14,7 @@ class BaseSettings(object):
         self.name = data['name']
         self.tie_rule = data['scoringSettings']['matchupTieRule']
         self.playoff_seed_tie_rule = data['scoringSettings']['playoffMatchupTieRule']
+        self.faab = data['acquisitionSettings']['isUsingAcquisitionBudget']
         divisions = data.get('scheduleSettings', {}).get('divisions', [])
         for division in divisions: self.division_map[division.get('id', 0)] = division.get('name')
 


### PR DESCRIPTION
Simple change to add `faab` boolean to league settings to determine if the league is using a free agent acquisition budget