### PR TITLE
fix: Use more accurate naming for settings

### DIFF
--- a/espn_api/base_settings.py
+++ b/espn_api/base_settings.py
@@ -13,7 +13,8 @@ class BaseSettings(object):
             self.trade_deadline = data['tradeSettings']['deadlineDate']
         self.name = data['name']
         self.tie_rule = data['scoringSettings']['matchupTieRule']
-        self.playoff_seed_tie_rule = data['scoringSettings']['playoffMatchupTieRule']
+        self.playoff_tie_rule = data['scoringSettings']['playoffMatchupTieRule']
+        self.playoff_seed_tie_rule = data['scheduleSettings']['playoffSeedingRule']
         self.scoring_type = data.get('scoringSettings', {}).get('scoringType')
         self.faab = data['acquisitionSettings']['isUsingAcquisitionBudget']
         divisions = data.get('scheduleSettings', {}).get('divisions', [])


### PR DESCRIPTION
Currently, the attribute `league.settings.playoff_seed_tie_rule` is assigned the value from `data['scoringSettings']['playoffMatchupTieRule']`. This is the rule used when there are ties in playoff matchups, _not_ the rule used when there are ties for playoff seeding. That rule can be found in data['scheduleSettings']['playoffSeedingRule']. This PR renames the old attribute `league.settings.playoff_tie_rule` (to be similar to `league.settings.tie_rule`, as these are similar settings), and instead assign `league.settings.playoff_seed_tie_rule` to the tiebreaker used when deciding playoff seeding.