### PR TITLE
fix: Verify home key exists when querying for matchup data

### DIFF
--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -55,7 +55,9 @@ class Team(object):
 
         for matchup in data:
             if 'away' in matchup.keys():
-                if matchup['away']['teamId'] == self.team_id:
+                if "home" not in matchup.keys():
+                    continue
+                elif matchup['away']['teamId'] == self.team_id:
                     score = matchup['away']['totalPoints']
                     opponentId = matchup['home']['teamId']
                     self.outcomes.append(self._get_winner(matchup['winner'], True))


### PR DESCRIPTION
* I discovered a bug which caused the intialization of the league object to crash.
* I believe this occurred because in my league we have an odd number of teams which results in one matchup each week having only one team and that team always appears to be the away team, 

When creating the outcomes object the code looks for the home and away keys even though they may not exist in the matchup object in a league with an odd number of teams. 

This PR adds a check to ensure the home key exists prior to lookup to avoid a crash. 


Here was the error I received, prior to implementing the fix.  
```
python3 main.py                                                                                                                                                                              ─╯
Traceback (most recent call last):
  File "/Users/jacobelias/Desktop/workspace/fantasy-football/main.py", line 605, in <module>
    main(swid, espn_s2, league_id, week)
  File "/Users/jacobelias/Desktop/workspace/fantasy-football/main.py", line 514, in main
    league = League(league_id=league_id, year=2022, espn_s2=espn_s2, swid=swid)
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/league.py", line 23, in __init__
    self.fetch_league()
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/league.py", line 26, in fetch_league
    self._fetch_league()
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/league.py", line 33, in _fetch_league
    self._fetch_teams(data)
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/league.py", line 38, in _fetch_teams
    super()._fetch_teams(data, TeamClass=Team)
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/base_league.py", line 63, in _fetch_teams
    self.teams.append(TeamClass(team, roster=roster, member=member, schedule=schedule, year=seasonId))
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/team.py", line 39, in __init__
    self._fetch_schedule(schedule)
  File "/opt/homebrew/lib/python3.10/site-packages/espn_api/football/team.py", line 66, in _fetch_schedule
    elif matchup['home']['teamId'] == self.team_id:
KeyError: 'home'
````

S/o to @wowcanubelieveit for providing the league with odd teams and the crash scenario, and for rapping dreams and nightmares to motivate  me while debugging