### PR TITLE
Only grab player stats for specified year

### DIFF
--- a/espn_api/basketball/player.py
+++ b/espn_api/basketball/player.py
@@ -33,18 +33,19 @@ class Player(object):
         self.injured = player.get('injured', False)
 
         for split in  player.get('stats', []):
-            id = self._stat_id_pretty(split['id'], split['scoringPeriodId'])
-            applied_total = split.get('appliedTotal', 0)
-            applied_avg =  round(split.get('appliedAverage', 0), 2)
-            game = self.schedule.get(id, {})
-            self.stats[id] = dict(applied_total=applied_total, applied_avg=applied_avg, team=game.get('team', None), date=game.get('date', None))
-            if split['stats']:
-                if 'averageStats' in split.keys():
-                    self.stats[id]['avg'] = {STATS_MAP.get(i, i): split['averageStats'][i] for i in split['averageStats'].keys() if STATS_MAP.get(i) != ''}
-                    self.stats[id]['total'] = {STATS_MAP.get(i, i): split['stats'][i] for i in split['stats'].keys() if STATS_MAP.get(i) != ''}
-                else:
-                    self.stats[id]['avg'] = None
-                    self.stats[id]['total'] = {STATS_MAP.get(i, i): split['stats'][i] for i in split['stats'].keys() if STATS_MAP.get(i) != ''}
+            if split['seasonId'] == year:
+                id = self._stat_id_pretty(split['id'], split['scoringPeriodId'])
+                applied_total = split.get('appliedTotal', 0)
+                applied_avg =  round(split.get('appliedAverage', 0), 2)
+                game = self.schedule.get(id, {})
+                self.stats[id] = dict(applied_total=applied_total, applied_avg=applied_avg, team=game.get('team', None), date=game.get('date', None))
+                if split['stats']:
+                    if 'averageStats' in split.keys():
+                        self.stats[id]['avg'] = {STATS_MAP.get(i, i): split['averageStats'][i] for i in split['averageStats'].keys() if STATS_MAP.get(i) != ''}
+                        self.stats[id]['total'] = {STATS_MAP.get(i, i): split['stats'][i] for i in split['stats'].keys() if STATS_MAP.get(i) != ''}
+                    else:
+                        self.stats[id]['avg'] = None
+                        self.stats[id]['total'] = {STATS_MAP.get(i, i): split['stats'][i] for i in split['stats'].keys() if STATS_MAP.get(i) != ''}
         self.total_points = self.stats.get(f'{year}_total', {}).get('applied_total', 0)
         self.avg_points = self.stats.get(f'{year}_total', {}).get('applied_avg', 0)
         self.projected_total_points= self.stats.get(f'{year}_projected', {}).get('applied_total', 0)


### PR DESCRIPTION
Prevents stats from being pulled from games in previous years. This could occur when a player had games with the same `scoringPeriodId` in multiple years