### PR TITLE
Add draft support for basketball

### DIFF
--- a/espn_api/basketball/pick.py
+++ b/espn_api/basketball/pick.py
@@ -1,0 +1,18 @@
+
+class Pick(object):
+    ''' Pick represents a pick in draft '''
+    def __init__(self, team, playerId, playerName, round_num, round_pick, bid_amount, keeper_status, nominatingTeam):
+        self.team = team
+        self.playerId = playerId
+        self.playerName = playerName
+        self.round_num = round_num
+        self.round_pick = round_pick
+        self.bid_amount = bid_amount
+        self.keeper_status = keeper_status
+        self.nominatingTeam = nominatingTeam
+
+    def __repr__(self):
+        return 'Pick(R:%s P:%s, %s, %s)' % (self.round_num, self.round_pick, self.playerName, self.team)
+
+    def auction_repr(self):
+        return ', '.join(map(str, [self.team.owner, self.playerId, self.playerName, self.bid_amount, self.keeper_status]))


### PR DESCRIPTION
Implements draft support for basketball. Copied over from the football implementation. Only change is the string representation in order to better display the round and pick number.

This should probably be moved to a base pick class, similar to what is planned for players with #124 , but this should do for now. Might also be worth considering adding a player object member instead of the separate name and id-- similar to how the team member is a team object