### PR TITLE
adding an offset parameter to support paging through all activities

### DIFF
--- a/espn_api/baseball/league.py
+++ b/espn_api/baseball/league.py
@@ -15,9 +15,9 @@ from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
-    
+
     ScoreTypes = {'H2H_CATEGORY': H2HCategoryBoxScore, 'H2H_POINTS': H2HPointsBoxScore}
-    
+
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='mlb', espn_s2=espn_s2, swid=swid, debug=debug)
 
@@ -25,12 +25,12 @@ class League(BaseLeague):
 
         self.scoring_type = None
         self._box_score_class = None
-        
+
         if fetch_league:
             data = self._fetch_league()
             self.scoring_type = data['settings']['scoringSettings']['scoringType']
             self._fetch_teams(data)
-        
+
         if self._box_score_class is None:
             self._box_score_class = self._set_scoring_class(self.scoring_type)
 
@@ -46,7 +46,7 @@ class League(BaseLeague):
         return data
 
     def _fetch_teams(self, data):
-        '''Fetch teams in league'''        
+        '''Fetch teams in league'''
         super()._fetch_teams(data, TeamClass=Team)
 
         # replace opponentIds in schedule with team instances
@@ -58,7 +58,7 @@ class League(BaseLeague):
                         matchup.away_team = opponent
                     if matchup.home_team == opponent.team_id:
                         matchup.home_team = opponent
-                        
+
     def standings(self) -> List[Team]:
         standings = sorted(self.teams, key=lambda x: x.final_standing if x.final_standing != 0 else x.standing, reverse=False)
         return standings
@@ -81,7 +81,7 @@ class League(BaseLeague):
                     matchup.home_team = team
                 elif matchup.away_team == team.team_id:
                     matchup.away_team = team
-        
+
         return matchups
 
     def get_team_data(self, team_id: int) -> Team:
@@ -90,7 +90,7 @@ class League(BaseLeague):
                 return team
         return None
 
-    def recent_activity(self, size: int = 25, msg_type: str = None) -> List[Activity]:
+    def recent_activity(self, size: int = 25, msg_type: str = None, offset: int = 0) -> List[Activity]:
         '''Returns a list of recent league activities (Add, Drop, Trade)'''
         if self.year < 2019:
             raise Exception('Cant use recent activity before 2019')
@@ -102,7 +102,7 @@ class League(BaseLeague):
             'view': 'kona_league_communication'
         }
 
-        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":0,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
+        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":offset,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
         data = self.espn_request.league_get(extend='/communication/', params=params, headers=headers)
         data = data['topics']
@@ -118,14 +118,14 @@ class League(BaseLeague):
             raise Exception('Cant use free agents before 2019')
         if not week:
             week = self.current_week
-        
+
         slot_filter = []
         if position and position in POSITION_MAP:
             slot_filter = [POSITION_MAP[position]]
         if position_id:
             slot_filter.append(position_id)
 
-        
+
         params = {
             'view': 'kona_player_info',
             'scoringPeriodId': week,

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -15,7 +15,7 @@ class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, debug=debug)
-        
+
         if fetch_league:
             self.fetch_league()
 
@@ -47,7 +47,7 @@ class League(BaseLeague):
 
     def _fetch_teams(self, data):
         '''Fetch teams in league'''
-        pro_schedule = self._get_all_pro_schedule()        
+        pro_schedule = self._get_all_pro_schedule()
         super()._fetch_teams(data, TeamClass=Team, pro_schedule=pro_schedule)
 
         # replace opponentIds in schedule with team instances
@@ -59,7 +59,7 @@ class League(BaseLeague):
                         matchup.away_team = opponent
                     if matchup.home_team == opponent.team_id:
                         matchup.home_team = opponent
-                        
+
     def _fetch_draft(self):
         '''Creates list of Pick objects from the leagues draft'''
         data = self.espn_request.get_league_draft()
@@ -104,7 +104,7 @@ class League(BaseLeague):
                     matchup.home_team = team
                 elif matchup.away_team == team.team_id:
                     matchup.away_team = team
-        
+
         return matchups
 
     def get_team_data(self, team_id: int) -> Team:
@@ -113,7 +113,7 @@ class League(BaseLeague):
                 return team
         return None
 
-    def recent_activity(self, size: int = 25, msg_type: str = None) -> List[Activity]:
+    def recent_activity(self, size: int = 25, msg_type: str = None, offset: int = 0) -> List[Activity]:
         '''Returns a list of recent league activities (Add, Drop, Trade)'''
         if self.year < 2019:
             raise Exception('Cant use recent activity before 2019')
@@ -125,7 +125,7 @@ class League(BaseLeague):
             'view': 'kona_league_communication'
         }
 
-        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":0,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
+        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":offset,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
         data = self.espn_request.league_get(extend='/communication/', params=params, headers=headers)
         data = data['topics']
@@ -141,14 +141,14 @@ class League(BaseLeague):
             raise Exception('Cant use free agents before 2019')
         if not week:
             week = self.current_week
-        
+
         slot_filter = []
         if position and position in POSITION_MAP:
             slot_filter = [POSITION_MAP[position]]
         if position_id:
             slot_filter.append(position_id)
 
-        
+
         params = {
             'view': 'kona_player_info',
             'scoringPeriodId': week,

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -19,7 +19,7 @@ class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nfl', espn_s2=espn_s2, swid=swid, debug=debug)
-        
+
         if fetch_league:
             self.fetch_league()
 
@@ -150,7 +150,7 @@ class League(BaseLeague):
                 return team
         return None
 
-    def recent_activity(self, size: int = 25, msg_type: str = None) -> List[Activity]:
+    def recent_activity(self, size: int = 25, msg_type: str = None, offset: int = 0) -> List[Activity]:
         '''Returns a list of recent league activities (Add, Drop, Trade)'''
         if self.year < 2019:
             raise Exception('Cant use recent activity before 2019')
@@ -162,7 +162,7 @@ class League(BaseLeague):
             'view': 'kona_league_communication'
         }
 
-        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":0,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
+        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":offset,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
         data = self.espn_request.league_get(extend='/communication/', params=params, headers=headers)
         data = data['topics']
@@ -296,7 +296,7 @@ class League(BaseLeague):
             return Player(data['players'][0], self.year)
         if len(data['players']) > 1:
             return [Player(player, self.year) for player in data['players']]
-    
+
     def message_board(self, msg_types: List[str] = None):
         ''' Returns a list of league messages'''
         data = self.espn_request.get_league_message_board(msg_types)

--- a/espn_api/hockey/league.py
+++ b/espn_api/hockey/league.py
@@ -90,7 +90,7 @@ class League(BaseLeague):
                 return team
         return None
 
-    def recent_activity(self, size: int = 25, msg_type: str = None) -> List[Activity]:
+    def recent_activity(self, size: int = 25, msg_type: str = None, offset: int = 0) -> List[Activity]:
         '''Returns a list of recent league activities (Add, Drop, Trade)'''
         if self.year < 2019:
             raise Exception('Cant use recent activity before 2019')
@@ -103,7 +103,7 @@ class League(BaseLeague):
         }
 
         filters = {"topics": {"filterType": {"value": ["ACTIVITY_TRANSACTIONS"]}, "limit": size,
-                              "limitPerMessageSet": {"value": 25}, "offset": 0,
+                              "limitPerMessageSet": {"value": 25}, "offset": offset,
                               "sortMessageDate": {"sortPriority": 1, "sortAsc": False},
                               "sortFor": {"sortPriority": 2, "sortAsc": False},
                               "filterIncludeMessageTypeIds": {"value": msg_types}}}

--- a/espn_api/wbasketball/league.py
+++ b/espn_api/wbasketball/league.py
@@ -17,10 +17,10 @@ class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='wnba', espn_s2=espn_s2, swid=swid, debug=debug)
-        
+
         if fetch_league:
             self._fetch_league()
-        
+
     def fetch_league(self):
         data = self._fetch_league()
         self._fetch_teams(data)
@@ -44,7 +44,7 @@ class League(BaseLeague):
 
 
     def _fetch_teams(self, data):
-        '''Fetch teams in league'''        
+        '''Fetch teams in league'''
         super()._fetch_teams(data, TeamClass=Team)
 
         # replace opponentIds in schedule with team instances
@@ -56,7 +56,7 @@ class League(BaseLeague):
                         matchup.away_team = opponent
                     if matchup.home_team == opponent.team_id:
                         matchup.home_team = opponent
-                        
+
 
 
     def standings(self) -> List[Team]:
@@ -81,7 +81,7 @@ class League(BaseLeague):
                     matchup.home_team = team
                 elif matchup.away_team == team.team_id:
                     matchup.away_team = team
-        
+
         return matchups
 
     def get_team_data(self, team_id: int) -> Team:
@@ -90,7 +90,7 @@ class League(BaseLeague):
                 return team
         return None
 
-    def recent_activity(self, size: int = 25, msg_type: str = None) -> List[Activity]:
+    def recent_activity(self, size: int = 25, msg_type: str = None, offset: int = 0) -> List[Activity]:
         '''Returns a list of recent league activities (Add, Drop, Trade)'''
         if self.year < 2019:
             raise Exception('Cant use recent activity before 2019')
@@ -102,7 +102,7 @@ class League(BaseLeague):
             'view': 'kona_league_communication'
         }
 
-        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":0,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
+        filters = {"topics":{"filterType":{"value":["ACTIVITY_TRANSACTIONS"]},"limit":size,"limitPerMessageSet":{"value":25},"offset":offset,"sortMessageDate":{"sortPriority":1,"sortAsc":False},"sortFor":{"sortPriority":2,"sortAsc":False},"filterIncludeMessageTypeIds":{"value":msg_types}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
         data = self.espn_request.league_get(extend='/communication/', params=params, headers=headers)
         data = data['topics']
@@ -118,14 +118,14 @@ class League(BaseLeague):
             raise Exception('Cant use free agents before 2019')
         if not week:
             week = self.current_week
-        
+
         slot_filter = []
         if position and position in POSITION_MAP:
             slot_filter = [POSITION_MAP[position]]
         if position_id:
             slot_filter.append(position_id)
 
-        
+
         params = {
             'view': 'kona_player_info',
             'scoringPeriodId': week,


### PR DESCRIPTION
Adds an optional parameter to support `offset` in the `recent_activity` method on `League`. 

The benefit of this is the code for retrieving recent activity (1000 events in my example) can be more finely controlled.

```python
league = League(...)
activity = league.recent_activity(1000)
```

is now

```python
league = League(...)
offset = 0
limit = 25
for True: # Implement a stopping condition
    activity = league.recent_activity(limit=limit, offset=offset)
    offset += limit
```

Looks like my editor also removed some blank space, I can add that back if it makes the PR tougher to read.