### PR TITLE
adding owners to Team

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -50,15 +50,12 @@ class BaseLeague(ABC):
         seasonId = data['seasonId']
 
         team_roster = {}
-        team_owners = {}
         for team in data['teams']:
             team_roster[team['id']] = team.get('roster', {})
-            team_owners[team['id']] = team.get('owners', [])
 
         for team in teams:
             roster = team_roster[team['id']]
-            owners = team_owners[team['id']]
-            self.teams.append(TeamClass(team, roster=roster, schedule=schedule, year=seasonId, pro_schedule=pro_schedule, owners=owners))
+            self.teams.append(TeamClass(team, roster=roster, schedule=schedule, year=seasonId, pro_schedule=pro_schedule))
 
         # sort by team ID
         self.teams = sorted(self.teams, key=lambda x: x.team_id, reverse=False)

--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -39,7 +39,7 @@ class BaseLeague(ABC):
         else:
             self.current_week = self.scoringPeriodId if self.scoringPeriodId <= data['status']['finalScoringPeriod'] else data['status']['finalScoringPeriod']
         self.settings = SettingsClass(data['settings'])
-        self.members = data['members']
+        self.members = data.get('members', [])
         return data
 
     def _fetch_teams(self, data, TeamClass, pro_schedule = None):

--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -50,10 +50,10 @@ class BaseLeague(ABC):
         seasonId = data['seasonId']
 
         team_roster = {}
+        team_owners = {}
         for team in data['teams']:
             team_roster[team['id']] = team.get('roster', {})
-
-        team_owners = self._get_team_owners(data)
+            team_owners[team['id']] = team.get('owners', [])
 
         for team in teams:
             roster = team_roster[team['id']]
@@ -96,17 +96,6 @@ class BaseLeague(ABC):
             pro_game = team.get('proGamesByScoringPeriod', {})
             pro_team_schedule[team['id']] = pro_game
         return pro_team_schedule
-
-    def _get_team_owners(self, data) -> dict:  
-        team_owners = {}
-        for team in data['teams']:
-            team_owners[team['id']] = []
-            for member in self.members:
-                for owner in team['owners']:
-                    if owner == member['id']:
-                        team_owners[team['id']].append(member)
-
-        return team_owners
 
     def standings(self) -> List:
         standings = sorted(self.teams, key=lambda x: x.final_standing if x.final_standing != 0 else x.standing, reverse=False)

--- a/espn_api/baseball/team.py
+++ b/espn_api/baseball/team.py
@@ -5,7 +5,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, owners, **kwargs):
+    def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -27,7 +27,7 @@ class Team(object):
         
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
-        self.owners = owners
+        self.owners = data.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/baseball/team.py
+++ b/espn_api/baseball/team.py
@@ -5,7 +5,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, **kwargs):
+    def __init__(self, data, roster, schedule, year, owners, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -27,6 +27,7 @@ class Team(object):
         
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
+        self.owners = owners
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -4,7 +4,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, **kwargs):
+    def __init__(self, data, roster, schedule, year, owners, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -30,6 +30,7 @@ class Team(object):
         
         self._fetch_roster(roster, year, kwargs.get('pro_schedule'))
         self._fetch_schedule(schedule)
+        self.owners = owners
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -4,7 +4,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, owners, **kwargs):
+    def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -30,7 +30,7 @@ class Team(object):
         
         self._fetch_roster(roster, year, kwargs.get('pro_schedule'))
         self._fetch_schedule(schedule)
-        self.owners = owners
+        self.owners = data.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -2,7 +2,7 @@ from .player import Player
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, owners, **kwargs):
+    def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -37,7 +37,7 @@ class Team(object):
         self.mov = []
         self._fetch_schedule(schedule)
         self._fetch_roster(roster, year)
-        self.owners = owners
+        self.owners = data.get('owners', [])
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name, )

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -2,7 +2,7 @@ from .player import Player
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, **kwargs):
+    def __init__(self, data, roster, schedule, year, owners, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -37,6 +37,7 @@ class Team(object):
         self.mov = []
         self._fetch_schedule(schedule)
         self._fetch_roster(roster, year)
+        self.owners = owners
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name, )

--- a/espn_api/hockey/team.py
+++ b/espn_api/hockey/team.py
@@ -6,7 +6,7 @@ from .player import Player
 class Team(object):
     '''Teams are part of the league'''
 
-    def __init__(self, data, roster, schedule, year, **kwargs):
+    def __init__(self, data, roster, schedule, year, owners, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -34,6 +34,7 @@ class Team(object):
 
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
+        self.owners = owners
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name,)

--- a/espn_api/hockey/team.py
+++ b/espn_api/hockey/team.py
@@ -6,7 +6,7 @@ from .player import Player
 class Team(object):
     '''Teams are part of the league'''
 
-    def __init__(self, data, roster, schedule, year, owners, **kwargs):
+    def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -34,7 +34,7 @@ class Team(object):
 
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
-        self.owners = owners
+        self.owners = data.get('owners', [])
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name,)

--- a/espn_api/wbasketball/team.py
+++ b/espn_api/wbasketball/team.py
@@ -4,7 +4,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, owners, **kwargs):
+    def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -31,7 +31,7 @@ class Team(object):
         
         self._fetch_roster(roster, year)
         self._fetch_schedule(schedule)
-        self.owners = owners
+        self.owners = data.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/wbasketball/team.py
+++ b/espn_api/wbasketball/team.py
@@ -4,7 +4,7 @@ from .constant import STATS_MAP
 
 class Team(object):
     '''Teams are part of the league'''
-    def __init__(self, data, roster, schedule, year, **kwargs):
+    def __init__(self, data, roster, schedule, year, owners, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
         if year < 2023:
@@ -31,6 +31,7 @@ class Team(object):
         
         self._fetch_roster(roster, year)
         self._fetch_schedule(schedule)
+        self.owners = owners
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/tests/hockey/unit/test_team.py
+++ b/tests/hockey/unit/test_team.py
@@ -15,13 +15,14 @@ class TestHockeyTeam(TestCase):
 
             self.team = self.data['teams'][3]
             self.team_roster = self.team['roster']
+            self.owners = self.team['owners']
 
     def test_team(self):
-        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year)
+        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year, owners=self.owners)
         self.assertEqual(team.team_abbrev, 'ESPC')
 
     def test_team_roster_df(self):
-        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year)
+        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year, owners=self.owners)
 
         self.assertEqual(len(team.roster), 25)
         self.assertEqual(team.roster[0].name, 'Thomas Chabot')

--- a/tests/hockey/unit/test_team.py
+++ b/tests/hockey/unit/test_team.py
@@ -15,14 +15,13 @@ class TestHockeyTeam(TestCase):
 
             self.team = self.data['teams'][3]
             self.team_roster = self.team['roster']
-            self.owners = self.team['owners']
 
     def test_team(self):
-        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year, owners=self.owners)
+        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year)
         self.assertEqual(team.team_abbrev, 'ESPC')
 
     def test_team_roster_df(self):
-        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year, owners=self.owners)
+        team = Team(self.team, roster= self.team_roster, schedule= self.schedule, year= self.year)
 
         self.assertEqual(len(team.roster), 25)
         self.assertEqual(team.roster[0].name, 'Thomas Chabot')


### PR DESCRIPTION
## Problem
Currently there's no way to get info on the "owner" (aka "manager") of a Team.  While the team's name is available, those are subject to change making tracking over longer periods difficult

## Solution
ESPN has a concept of Members on a League and Owners on a Team.  These are tied together by an Id and the Member entity has much more stable information about the actual humans behind the team.
Storing this Member info with the Team will make that info more accessible

## Code Changes
* added members property to the League
* modified BaseLeague fetch_teams to create and an array of members associated with the owners of each Team
* added owners property and constructor parameter to Teams