### PR TITLE
Past Team Name Use New Field

### DIFF
--- a/espn_api/baseball/team.py
+++ b/espn_api/baseball/team.py
@@ -8,10 +8,7 @@ class Team(object):
     def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
-        if year < 2023:
-            self.team_name = "%s %s" % (data.get('location', 'Unknown'), data.get('nickname', 'Unknown'))
-        else:
-            self.team_name = data.get('name', 'Unknown')
+        self.team_name = data.get('name', 'Unknown')
         self.division_id = data['divisionId']
         self.division_name = '' # set by caller
         self.wins = data['record']['overall']['wins']

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -7,10 +7,7 @@ class Team(object):
     def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
-        if year < 2023:
-            self.team_name = "%s %s" % (data.get('location', 'Unknown'), data.get('nickname', 'Unknown'))
-        else:
-            self.team_name = data.get('name', 'Unknown')
+        self.team_name = data.get('name', 'Unknown')
         self.division_id = data['divisionId']
         self.division_name = '' # set by caller
         self.wins = data['record']['overall']['wins']

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -5,10 +5,7 @@ class Team(object):
     def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
-        if year < 2023:
-            self.team_name = "%s %s" % (data.get('location', 'Unknown'), data.get('nickname', 'Unknown'))
-        else:
-            self.team_name = data.get('name', 'Unknown')
+        self.team_name = data.get('name', 'Unknown')
         self.division_id = data['divisionId']
         self.division_name = '' # set by caller
         self.wins = data['record']['overall']['wins']

--- a/espn_api/hockey/team.py
+++ b/espn_api/hockey/team.py
@@ -9,10 +9,7 @@ class Team(object):
     def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
-        if year < 2023:
-            self.team_name = "%s %s" % (data.get('location', 'Unknown'), data.get('nickname', 'Unknown'))
-        else:
-            self.team_name = data.get('name', 'Unknown')
+        self.team_name = data.get('name', 'Unknown')
         self.division_id = data['divisionId']
         self.division_name = ''  # set by caller
         self.wins = data['record']['overall']['wins']

--- a/espn_api/wbasketball/team.py
+++ b/espn_api/wbasketball/team.py
@@ -7,10 +7,7 @@ class Team(object):
     def __init__(self, data, roster, schedule, year, **kwargs):
         self.team_id = data['id']
         self.team_abbrev = data['abbrev']
-        if year < 2023:
-            self.team_name = "%s %s" % (data.get('location', 'Unknown'), data.get('nickname', 'Unknown'))
-        else:
-            self.team_name = data.get('name', 'Unknown')
+        self.team_name = data.get('name', 'Unknown')
         self.division_id = data['divisionId']
         self.division_name = '' # set by caller
         self.wins = data['record']['overall']['wins']


### PR DESCRIPTION
Looks like they back filled previous data to new team name and removed old way. Keeping old way just in case they didn't do it for every sport