### PR TITLE
feat: Add active status to `Player`

### DIFF
--- a/espn_api/football/player.py
+++ b/espn_api/football/player.py
@@ -49,13 +49,11 @@ class Player(object):
         self.projected_total_points = self.stats.get(0, {}).get('projected_points', 0)
         self.avg_points = self.stats.get(0, {}).get('avg_points', 0)
         self.projected_avg_points = self.stats.get(0, {}).get('projected_avg_points', 0)
-
             if not stat_source:
                 if not self.stats[scoring_period][breakdown_type]:
                     self.active_status = 'inactive'
                 else:
                     self.active_status = 'active'
-
 
     def __repr__(self):
         return f'Player({self.name})'

--- a/espn_api/football/player.py
+++ b/espn_api/football/player.py
@@ -27,6 +27,7 @@ class Player(object):
         self.percent_owned = round(player.get('ownership', {}).get('percentOwned', -1), 2)
         self.percent_started = round(player.get('ownership', {}).get('percentStarted', -1), 2)
 
+        self.active_status = 'bye'
         player_stats = player.get('stats', [])
         for stats in player_stats:
             if stats.get('seasonId') != year:
@@ -48,6 +49,13 @@ class Player(object):
         self.projected_total_points = self.stats.get(0, {}).get('projected_points', 0)
         self.avg_points = self.stats.get(0, {}).get('avg_points', 0)
         self.projected_avg_points = self.stats.get(0, {}).get('projected_avg_points', 0)
+
+            if not stat_source:
+                if not self.stats[scoring_period][breakdown_type]:
+                    self.active_status = 'inactive'
+                else:
+                    self.active_status = 'active'
+
 
     def __repr__(self):
         return f'Player({self.name})'

--- a/espn_api/football/player.py
+++ b/espn_api/football/player.py
@@ -45,15 +45,15 @@ class Player(object):
                 self.stats[scoring_period][avg_type] = avg_points
             else:
                 self.stats[scoring_period] = {points_type: points, breakdown_type: breakdown, avg_type: avg_points}
-        self.total_points = self.stats.get(0, {}).get('points', 0)
-        self.projected_total_points = self.stats.get(0, {}).get('projected_points', 0)
-        self.avg_points = self.stats.get(0, {}).get('avg_points', 0)
-        self.projected_avg_points = self.stats.get(0, {}).get('projected_avg_points', 0)
             if not stat_source:
                 if not self.stats[scoring_period][breakdown_type]:
                     self.active_status = 'inactive'
                 else:
                     self.active_status = 'active'
+        self.total_points = self.stats.get(0, {}).get('points', 0)
+        self.projected_total_points = self.stats.get(0, {}).get('projected_points', 0)
+        self.avg_points = self.stats.get(0, {}).get('avg_points', 0)
+        self.projected_avg_points = self.stats.get(0, {}).get('projected_avg_points', 0)
 
     def __repr__(self):
         return f'Player({self.name})'


### PR DESCRIPTION
This PR can finally resolve a long-standing issue... historical injury status! For a while now, an issue (https://github.com/cwendt94/espn-api/issues/327, https://github.com/cwendt94/espn-api/issues/401) we've had is that ESPN only return's a player's current health status, even when querying a previous week or year. I think I have a way to get around this and assume a player's health status from previous weeks.

This uses the embedded stats objects to decipher whether a player was active in a historical week.
* `active`: the player had a game and participated in it
* `inactive`: the player had a game but did not participate in it (due to injury or suspension)
* `bye`: the player did not have a game that week

Testing and research can be viewed [here](https://github.com/DesiPilla/espn-api-v3/issues/15#issuecomment-1817336010).