### PR TITLE
Update hockey positions

### DIFF
--- a/espn_api/hockey/constant.py
+++ b/espn_api/hockey/constant.py
@@ -1,20 +1,23 @@
 #Constants
 POSITION_MAP = {
-    # Remaining: F, IR, Util
-    0 : '0' # IR?
-    , 1 : 'Center'
-    , 2 : 'Left Wing'
-    , 3 : 'Right Wing'
+    0 : 'Center'
+    , 1 : 'Left Wing'
+    , 2 : 'Right Wing'
+    , 3 : 'Forward'
     , 4 : 'Defense'
     , 5 : 'Goalie'
-    , 6 : '6' # Forward ?
-    , 7 : '7' # Goalie, F (Goalie Bench?)
-    , 8 : '8' # Goalie, F
-    , 'Center': 1
-    , 'Left Wing' : 2
-    , 'Right Wing' : 3
+    , 6 : 'Util'
+    , 7 : 'Bench'
+    , 8 : 'IR'
+    , 'Center': 0
+    , 'Left Wing' : 1
+    , 'Right Wing' : 2
+    , 'Forward' : 3
     , 'Defense' : 4
     , 'Goalie' : 5
+    , 'Util' : 6
+    , 'Bench' : 7
+    , 'IR' : 8
 }
 
 STATS_IDENTIFIER = {

--- a/espn_api/hockey/player.py
+++ b/espn_api/hockey/player.py
@@ -10,9 +10,7 @@ class Player(object):
         self.position = POSITION_MAP.get(json_parsing(data, 'defaultPositionId') - 1
                                          if json_parsing(data, 'defaultPositionId') and json_parsing(data, 'defaultPositionId') <= 3 
                                          else json_parsing(data, 'defaultPositionId'), '')
-        self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId') - 1
-                                           if data.get('lineupSlotId') and data.get('lineupSlotId') <= 3 
-                                           else data.get('lineupSlotId'), '')
+        self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId'), '')
         self.eligibleSlots = [POSITION_MAP.get(pos, '') for pos in json_parsing(data, 'eligibleSlots')]
         self.acquisitionType = json_parsing(data, 'acquisitionType')
         self.proTeam = PRO_TEAM_MAP.get(json_parsing(data, 'proTeamId'), 'Unknown Team')

--- a/espn_api/hockey/player.py
+++ b/espn_api/hockey/player.py
@@ -7,8 +7,12 @@ class Player(object):
     def __init__(self, data):
         self.name = json_parsing(data, 'fullName')
         self.playerId = json_parsing(data, 'id')
-        self.position = POSITION_MAP.get(json_parsing(data, 'defaultPositionId'), '')
-        self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId'), '')
+        self.position = POSITION_MAP.get(json_parsing(data, 'defaultPositionId') - 1
+                                         if json_parsing(data, 'defaultPositionId') and json_parsing(data, 'defaultPositionId') <= 3 
+                                         else json_parsing(data, 'defaultPositionId'), '')
+        self.lineupSlot = POSITION_MAP.get(data.get('lineupSlotId') - 1
+                                           if data.get('lineupSlotId') and data.get('lineupSlotId') <= 3 
+                                           else data.get('lineupSlotId'), '')
         self.eligibleSlots = [POSITION_MAP.get(pos, '') for pos in json_parsing(data, 'eligibleSlots')]
         self.acquisitionType = json_parsing(data, 'acquisitionType')
         self.proTeam = PRO_TEAM_MAP.get(json_parsing(data, 'proTeamId'), 'Unknown Team')


### PR DESCRIPTION
Hockey positions don't hold the same key:value relationship between the `eligibleSlots` and `lineupSlot` fields and the `position` field under player.py. 

Modified constant.py to match the `eligibleSlots ` and `lineupSlot` values (which has an extra 'Forward' value) and reconfigured the Player() init to account for the mismatch in keys.