### PR TITLE
feat: Add `previousSeasons` to `BaseLeague` object

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -34,6 +34,7 @@ class BaseLeague(ABC):
         self.scoringPeriodId = data['scoringPeriodId']
         self.firstScoringPeriod = data['status']['firstScoringPeriod']
         self.finalScoringPeriod = data['status']['finalScoringPeriod']
+        self.previousSeasons = data["status"]["previousSeasons"]
         if self.year < 2018:
             self.current_week = data['scoringPeriodId']
         else:

--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -34,7 +34,9 @@ class BaseLeague(ABC):
         self.scoringPeriodId = data['scoringPeriodId']
         self.firstScoringPeriod = data['status']['firstScoringPeriod']
         self.finalScoringPeriod = data['status']['finalScoringPeriod']
-        self.previousSeasons = data["status"]["previousSeasons"]
+        self.previousSeasons = [
+            year for year in data["status"]["previousSeasons"] if year < self.year
+        ]
         if self.year < 2018:
             self.current_week = data['scoringPeriodId']
         else:


### PR DESCRIPTION
Add a list of all previous seasons for a league. I know this is accurate for football leagues, and I assume(?) this is the same across all ESPN leagues and should be a part of the `BaseLeague` object.