### PR TITLE
feat: Add full owner info to team

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -48,6 +48,7 @@ class BaseLeague(ABC):
         teams = data['teams']
         schedule = data['schedule']
         seasonId = data['seasonId']
+        members = data.get('members', [])
 
         team_roster = {}
         for team in data['teams']:
@@ -55,7 +56,8 @@ class BaseLeague(ABC):
 
         for team in teams:
             roster = team_roster[team['id']]
-            self.teams.append(TeamClass(team, roster=roster, schedule=schedule, year=seasonId, pro_schedule=pro_schedule))
+            owners = [member for member in members if member.get('id') == team.get('owners', [''])[0]]
+            self.teams.append(TeamClass(team, roster=roster, schedule=schedule, year=seasonId, owners=owners, pro_schedule=pro_schedule))
 
         # sort by team ID
         self.teams = sorted(self.teams, key=lambda x: x.team_id, reverse=False)

--- a/espn_api/baseball/team.py
+++ b/espn_api/baseball/team.py
@@ -26,7 +26,7 @@ class Team(object):
         
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
-        self.owners = data.get('owners', [])
+        self.owners = kwargs.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -29,7 +29,7 @@ class Team(object):
         
         self._fetch_roster(roster, year, kwargs.get('pro_schedule'))
         self._fetch_schedule(schedule)
-        self.owners = data.get('owners', [])
+        self.owners = kwargs.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -37,7 +37,6 @@ class Team(object):
         self._fetch_schedule(schedule)
         self._fetch_roster(roster, year)
         self.owners = kwargs.get('owners', [])
-        print(self.owners)
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name, )

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -36,7 +36,8 @@ class Team(object):
         self.mov = []
         self._fetch_schedule(schedule)
         self._fetch_roster(roster, year)
-        self.owners = data.get('owners', [])
+        self.owners = kwargs.get('owners', [])
+        print(self.owners)
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name, )

--- a/espn_api/hockey/team.py
+++ b/espn_api/hockey/team.py
@@ -33,7 +33,7 @@ class Team(object):
 
         self._fetch_roster(roster)
         self._fetch_schedule(schedule)
-        self.owners = data.get('owners', [])
+        self.owners = kwargs.get('owners', [])
 
     def __repr__(self):
         return 'Team(%s)' % (self.team_name,)

--- a/espn_api/wbasketball/team.py
+++ b/espn_api/wbasketball/team.py
@@ -30,7 +30,7 @@ class Team(object):
         
         self._fetch_roster(roster, year)
         self._fetch_schedule(schedule)
-        self.owners = data.get('owners', [])
+        self.owners = kwargs.get('owners', [])
         
     def __repr__(self):
         return f'Team({self.team_name})'


### PR DESCRIPTION
feat: #497

Team.owners will now be an array of dict. It will look like
```
{ id: '1234', displayName: 'team', firstName: 'Bob', lastName: 'Joe'}
```
However in public leagues, the name attributes will not be populated.