### PR TITLE
feat: Add standings_weekly method Football League Class

### DIFF
--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -115,6 +115,41 @@ class League(BaseLeague):
     def standings(self) -> List[Team]:
         standings = sorted(self.teams, key=lambda x: x.final_standing if x.final_standing != 0 else x.standing, reverse=False)
         return standings
+    
+    def standings_weekly(self, week: int = None) -> List[Team]:
+        """
+        Returns league standings for the end of a particular week by calculating
+        wins, losses, points for and points against from week 1 to the week provided.
+        
+        Args:
+            week (int, optional): Week to return standings. Defaults to None.
+
+        Returns:
+            List[Team]: List of ESPN FF team objects in order of standing.
+        """
+        if not week or week <= 0 or week > self.current_week:
+            week = self.current_week
+
+        # Initialize a dictionary to hold team records
+        team_records = {team.team_id: {'wins': 0, 'losses': 0, 'points_for': 0, 'points_against': 0} for team in self.teams}
+
+        # Calculate wins, losses, points for, and points against for each team
+        for team in self.teams:
+            for i in range(week):
+                opponent = team.schedule[i]
+                team_points = team.scores[i]
+                opponent_points = opponent.scores[i]
+                if team_points > opponent_points:
+                    team_records[team.team_id]['wins'] += 1
+                else:
+                    team_records[team.team_id]['losses'] += 1
+                team_records[team.team_id]['points_for'] += team_points
+                team_records[team.team_id]['points_against'] += opponent_points
+
+        # Sort teams based on wins, then points for, and then points against
+        sorted_teams = sorted(self.teams, key=lambda x: (team_records[x.team_id]['wins'], team_records[x.team_id]['losses'], team_records[x.team_id]['points_for'], -team_records[x.team_id]['points_against']), reverse=True)
+
+        return sorted_teams
 
     def top_scorer(self) -> Team:
         most_pf = sorted(self.teams, key=lambda x: x.points_for, reverse=True)

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -211,6 +211,24 @@ class LeagueTest(TestCase):
         valid_week = league.power_rankings(13)
         self.assertEqual(valid_week[0][0], '71.15')
         self.assertEqual(repr(valid_week[0][1]), 'Team(Perscription Mixon)')
+        
+    @requests_mock.Mocker()
+    def test_standings_weekly(self, m):
+        self.mock_setUp(m)
+
+        league = League(self.league_id, self.season)
+
+        invalid_week = league.standings_weekly(0)
+        current_week = league.standings_weekly(league.current_week)
+        self.assertEqual(invalid_week, current_week)
+
+        empty_week = league.standings_weekly()
+        self.assertEqual(empty_week, current_week)
+
+        valid_week = league.standings_weekly(13)
+        self.assertEqual(valid_week[0].standing, 1)
+        #self.assertEqual(valid_week[0][0], '71.15')
+        #self.assertEqual(repr(valid_week[0][1]), 'Team(Perscription Mixon)')
 
     @requests_mock.Mocker()
     @mock.patch.object(League, '_get_pro_schedule')   


### PR DESCRIPTION
Method of the Football League class that will return a list of teams in the order of their standing for a current week. The method calculates the number of wins, losses, points for and points against from week 1 to the provided week. If no week is provided, it will calculate to the league.current_week.

Included test for the method as well.