### PR TITLE
feat: Add method to calculate historical standings for any week

### DIFF
--- a/espn_api/football/helper.py
+++ b/espn_api/football/helper.py
@@ -13,8 +13,8 @@ def build_division_record_dict(team_data_list: List[Dict]) -> Dict:
     # Loop through each team's schedule and outcomes and build the dictionary
     for team_data in team_data_list:
         team = team_data["team"]
-        for opp, outcome in zip(team.schedule, team.outcomes):
-            if team.division_id == opp.division_id:
+        for opp, outcome in zip(team_data["schedule"], team_data["outcomes"]):
+            if team_data["division_id"] == opp.division_id:
                 if outcome == "W":
                     div_outcomes[team_data["team_id"]]["wins"] += 1
                 if outcome == "T":
@@ -48,6 +48,11 @@ def build_h2h_dict(team_data_list: List[Dict]) -> Dict:
     for team_data in team_data_list:
         team = team_data["team"]
         for opp, outcome in zip(team_data["schedule"], team_data["outcomes"]):
+            # Ignore teams that are not part of this tiebreaker
+            if opp.team_id not in h2h_outcomes[team.team_id].keys():
+                continue
+
+            # Add the outcome to the dictionary
             if outcome == "W":
                 h2h_outcomes[team.team_id][opp.team_id]["wins"] += 1
             if outcome == "T":
@@ -109,6 +114,9 @@ def sort_by_head_to_head(
     team_data_list: List[Dict],
 ) -> List[Dict]:
     """Take a list of team standings data and sort it using the H2H_RECORD tiebreaker"""
+    # Create a dictionary with each team's head to head record
+    h2h_dict = build_h2h_dict(team_data_list)
+
     # If there is only one team, return the dataframe as-is
     if len(team_data_list) < 2:
         return team_data_list

--- a/espn_api/football/helper.py
+++ b/espn_api/football/helper.py
@@ -1,0 +1,198 @@
+import random
+from typing import Callable, Dict, List, Tuple
+
+
+def build_division_record_dict(team_data_list: List[Dict]) -> Dict:
+    """Create a DataFrame with each team's divisional record."""
+    # Create a dictionary with each team's divisional record
+    div_outcomes = {
+        team_data["team_id"]: {"wins": 0, "divisional_games": 0}
+        for team_data in team_data_list
+    }
+
+    # Loop through each team's schedule and outcomes and build the dictionary
+    for team_data in team_data_list:
+        team = team_data["team"]
+        for opp, outcome in zip(team.schedule, team.outcomes):
+            if team.division_id == opp.division_id:
+                if outcome == "W":
+                    div_outcomes[team_data["team_id"]]["wins"] += 1
+                if outcome == "T":
+                    div_outcomes[team_data["team_id"]]["wins"] += 0.5
+
+                div_outcomes[team_data["team_id"]]["divisional_games"] += 1
+
+    # Calculate the divisional record
+    div_record = {
+        team_data["team_id"]: (
+            div_outcomes[team_data["team_id"]]["wins"]
+            / max(div_outcomes[team_data["team_id"]]["divisional_games"], 1)
+        )
+        for team_data in team_data_list
+    }
+
+    return div_record
+
+
+def build_h2h_dict(team_data_list: List[Dict]) -> Dict:
+    """Create a dictionary with each team's divisional record."""
+    # Create a dictionary with each team's head to head record
+    h2h_outcomes = {
+        team_data["team_id"]: {
+            opp["team_id"]: {"wins": 0, "h2h_games": 0} for opp in team_data_list
+        }
+        for team_data in team_data_list
+    }
+
+    # Loop through each team's schedule and outcomes and build the dictionary
+    for team_data in team_data_list:
+        team = team_data["team"]
+        for opp, outcome in zip(team_data["schedule"], team_data["outcomes"]):
+            if outcome == "W":
+                h2h_outcomes[team.team_id][opp.team_id]["wins"] += 1
+            if outcome == "T":
+                h2h_outcomes[team.team_id][opp.team_id]["wins"] += 0.5
+
+            h2h_outcomes[team.team_id][opp.team_id]["h2h_games"] += 1
+
+    # Calculate the head to head record
+    h2h_record = {
+        team_data["team_id"]: {
+            opp_data["team_id"]: (
+                h2h_outcomes[team_data["team_id"]][opp_data["team_id"]]["wins"]
+                / max(
+                    h2h_outcomes[team_data["team_id"]][opp_data["team_id"]][
+                        "h2h_games"
+                    ],
+                    1,
+                )
+            )
+            for opp_data in team_data_list
+        }
+        for team_data in team_data_list
+    }
+
+    return h2h_record
+
+
+def sort_by_win_pct(team_data_list: List[Dict]) -> List[Dict]:
+    """Take a list of team standings data and sort it using the TOTAL_POINTS_SCORED tiebreaker"""
+    return sorted(team_data_list, key=lambda x: x["win_pct"], reverse=True)
+
+
+def sort_by_points_for(team_data_list: List[Dict]) -> List[Dict]:
+    """Take a list of team standings data and sort it using the TOTAL_POINTS_SCORED tiebreaker"""
+    return sorted(team_data_list, key=lambda x: x["points_for"], reverse=True)
+
+
+def sort_by_division_record(team_data_list: List[Dict]) -> List[Dict]:
+    """Take a list of team standings data and sort it using the 3rd level tiebreaker"""
+    division_records = build_division_record_dict(team_data_list)
+    for team_data in team_data_list:
+        team_data["division_record"] = division_records[team_data["team_id"]]
+    return sorted(team_data_list, key=lambda x: x["division_record"], reverse=True)
+
+
+def sort_by_points_against(team_data_list: List[Dict]) -> List[Dict]:
+    """Take a list of team standings data and sort it using the 4th level tiebreaker"""
+    return sorted(team_data_list, key=lambda x: x["points_against"], reverse=True)
+
+
+def sort_by_coin_flip(team_data_list: List[Dict]) -> List[Dict]:
+    """Take a list of team standings data and sort it using the 5th level tiebreaker"""
+    for team_data in team_data_list:
+        team_data["coin_flip"] = random.random()
+    return sorted(team_data_list, key=lambda x: x["coin_flip"], reverse=True)
+
+
+def sort_by_head_to_head(
+    team_data_list: List[Dict],
+) -> List[Dict]:
+    """Take a list of team standings data and sort it using the H2H_RECORD tiebreaker"""
+    # If there is only one team, return the dataframe as-is
+    if len(team_data_list) < 2:
+        return team_data_list
+
+    # If there are only two teams, sort descending by H2H wins
+    elif len(h2h_dict) == 2:
+        # Filter the H2H DataFrame to only include the teams in question
+        h2h_dict = build_h2h_dict(team_data_list)
+
+        for team_data in team_data_list:
+            team_data["h2h_wins"] = h2h_dict[team_data["team_id"]]["h2h_wins"]
+        return sorted(team_data_list, key=lambda x: x["h2h_wins"], reverse=True)
+
+    # If there are more than two teams...
+    else:
+        # Filter the H2H DataFrame to only include the teams in question
+        h2h_dict = build_h2h_dict(team_data_list)
+
+        # Check if the teams have all played each other an equal number of times
+        matchup_counts = [
+            h2h_dict[opp]["h2h_games"]
+            for opp in h2h_dict[team_id].keys()
+            for team_id in h2h_dict.keys()
+        ]
+        if len(set(matchup_counts)) == 1:
+            # All teams have played each other an equal number of times
+            # Sort the teams by total H2H wins against each other
+            for team_data in team_data_list:
+                team_data["h2h_wins"] = h2h_dict[team_data["team_id"]]["h2h_wins"]
+            return sorted(team_data_list, key=lambda x: x["h2h_wins"], reverse=True)
+        else:
+            # All teams have not played each other an equal number of times
+            # This tiebreaker is invalid
+            for team_data in team_data_list:
+                team_data["h2h_wins"] = 0
+            return team_data_list
+
+
+def sort_team_data_list(
+    team_data_list: List[Dict],
+    tiebreaker_hierarchy: List[Tuple[Callable, str]],
+) -> List[Dict]:
+    """This recursive function sorts a list of team standings data by the tiebreaker hierarchy.
+    It iterates through each tiebreaker, sorting any remaning ties by the next tiebreaker.
+
+    Args:
+        team_data_list (List[Dict]): List of team data dictionaries
+        tiebreaker_hierarchy (List[Tuple[Callable, str]]): List of tiebreaker functions and columns to sort by
+
+    Returns:
+        List[Dict]: Sorted list of team data dictionaries
+    """
+    # If there are no more tiebreakers, return the standings list as-is
+    if not tiebreaker_hierarchy:
+        return team_data_list
+
+    # If there is only one team to sort, return the standings list as-is
+    if len(team_data_list) == 1:
+        return team_data_list
+
+    # Get the tiebreaker function and column name to group by
+    tiebreaker_function = tiebreaker_hierarchy[0][0]
+    tiebreaker_col = tiebreaker_hierarchy[0][1]
+
+    # Apply the tiebreaker function to the standings list
+    team_data_list = tiebreaker_function(team_data_list)
+
+    # Loop through each remaining unique tiebreaker value to see if ties remain
+    sorted_team_data_list = []
+    for val in sorted(
+        set([team_data[tiebreaker_col] for team_data in team_data_list]),
+        reverse=True,
+    ):
+        # Filter the standings list to only include the teams with the current tiebreaker value
+        team_data_subset = [
+            team_data
+            for team_data in team_data_list
+            if team_data[tiebreaker_col] == val
+        ]
+
+        # Append the sorted subset to the final sorted standings list
+        sorted_team_data_list = sorted_team_data_list + sort_team_data_list(
+            team_data_subset,
+            tiebreaker_hierarchy[1:],
+        )
+
+    return sorted_team_data_list

--- a/espn_api/football/helper.py
+++ b/espn_api/football/helper.py
@@ -39,7 +39,9 @@ def build_h2h_dict(team_data_list: List[Dict]) -> Dict:
     # Create a dictionary with each team's head to head record
     h2h_outcomes = {
         team_data["team_id"]: {
-            opp["team_id"]: {"h2h_wins": 0, "h2h_games": 0} for opp in team_data_list
+            opp["team_id"]: {"h2h_wins": 0, "h2h_games": 0}
+            for opp in team_data_list
+            if opp["team_id"] != team_data["team_id"]
         }
         for team_data in team_data_list
     }
@@ -126,7 +128,7 @@ def sort_by_head_to_head(
         for team_data in team_data_list:
             team_data["h2h_wins"] = sum(
                 h2h_dict[team_data["team_id"]][opp_id]["h2h_wins"]
-                for opp_id in h2h_dict.keys()
+                for opp_id in h2h_dict[team_data["team_id"]].keys()
             )
         return sorted(team_data_list, key=lambda x: x["h2h_wins"], reverse=True)
 
@@ -137,9 +139,9 @@ def sort_by_head_to_head(
 
         # Check if the teams have all played each other an equal number of times
         matchup_counts = [
-            h2h_dict[opp]["h2h_games"]
-            for opp in h2h_dict[team_id].keys()
+            h2h_dict[team_id][opp_id]["h2h_games"]
             for team_id in h2h_dict.keys()
+            for opp_id in h2h_dict[team_id].keys()
         ]
         if len(set(matchup_counts)) == 1:
             # All teams have played each other an equal number of times
@@ -147,7 +149,7 @@ def sort_by_head_to_head(
             for team_data in team_data_list:
                 team_data["h2h_wins"] = sum(
                     h2h_dict[team_data["team_id"]][opp_id]["h2h_wins"]
-                    for opp_id in h2h_dict.keys()
+                    for opp_id in h2h_dict[team_data["team_id"]].keys()
                 )
             return sorted(team_data_list, key=lambda x: x["h2h_wins"], reverse=True)
         else:

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -1,7 +1,9 @@
-import datetime
-import time
 import json
-from typing import List, Tuple, Union
+from itertools import combinations
+from typing import Callable, Dict, List, Tuple, Union
+
+import pandas as pd
+
 
 from ..base_league import BaseLeague
 from .team import Team
@@ -14,6 +16,7 @@ from .activity import Activity
 from .settings import Settings
 from .utils import power_points, two_step_dominance
 from .constant import POSITION_MAP, ACTIVITY_MAP
+
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
@@ -115,6 +118,108 @@ class League(BaseLeague):
     def standings(self) -> List[Team]:
         standings = sorted(self.teams, key=lambda x: x.final_standing if x.final_standing != 0 else x.standing, reverse=False)
         return standings
+
+    def standings_weekly(self, week: int) -> pd.DataFrame:
+        """This is the main function to get the standings for a given week.
+
+        It controls the tiebreaker hierarchy and calls the recursive League()._sort_standings_df function.
+        First, the division winners must be determined. Then, the rest of the teams are sorted.
+
+        The standard tiebreaker hierarchy is:
+            1. Head-to-head record among the tied teams
+            2. Total points scored for the season
+            3. Division record (if all tied teams are in the same division)
+            4. Total points scored against for the season
+            5. Coin flip
+
+        Args:
+            week (int): Week to get the standings for
+
+        Returns:
+            pd.DataFrame: Sorted standings DataFrame
+        """
+        # Build the standings DataFrame for the given week
+        standings_df = pd.DataFrame()
+        standings_df["team_id"] = [team.team_id for team in self.teams]
+        standings_df["team_name"] = [team.team_name for team in self.teams]
+        standings_df["division_id"] = [team.division_id for team in self.teams]
+        standings_df["division_name"] = [team.division_name for team in self.teams]
+        standings_df["wins"] = [
+            sum([1 for outcome in team.outcomes[:week] if outcome == "W"])
+            for team in self.teams
+        ]
+        standings_df["ties"] = [
+            sum([1 for outcome in team.outcomes[:week] if outcome == "T"])
+            for team in self.teams
+        ]
+        standings_df["losses"] = [
+            sum([1 for outcome in team.outcomes[:week] if outcome == "L"])
+            for team in self.teams
+        ]
+        standings_df["points_for"] = [sum(team.scores[:week]) for team in self.teams]
+        standings_df["points_against"] = [
+            sum([team.schedule[w].scores[w] for w in range(week)])
+            for team in self.teams
+        ]
+        standings_df["win_pct"] = (
+            standings_df["wins"] + standings_df["ties"] / 2
+        ) / standings_df[["wins", "losses", "ties"]].sum(axis=1)
+        standings_df.set_index("team_id", inplace=True)
+
+        if self.settings.playoff_seed_tie_rule == "TOTAL_POINTS_SCORED":
+            tiebreaker_hierarchy = [
+                (self._sort_by_win_pct, "win_pct"),
+                (self._sort_by_points_for, "points_for"),
+                (self._sort_by_head_to_head, "h2h_wins"),
+                (self._sort_by_division_record, "division_record"),
+                (self._sort_by_points_against, "points_against"),
+                (self._sort_by_coin_flip, "coin_flip"),
+            ]
+        elif self.settings.playoff_seed_tie_rule == "H2H_RECORD":
+            tiebreaker_hierarchy = [
+                (self._sort_by_win_pct, "win_pct"),
+                (self._sort_by_head_to_head, "h2h_wins"),
+                (self._sort_by_points_for, "points_for"),
+                (self._sort_by_division_record, "division_record"),
+                (self._sort_by_points_against, "points_against"),
+                (self._sort_by_coin_flip, "coin_flip"),
+            ]
+        else:
+            raise ValueError(
+                "Unkown tiebreaker_method: Must be either 'TOTAL_POINTS_SCORED' or 'H2H_RECORD'"
+            )
+
+        # First assign the division winners
+        division_winners = pd.DataFrame()
+        for division_id in standings_df.division_id.unique():
+            division_standings = standings_df[(standings_df.division_id == division_id)]
+            division_winner = self._sort_standings_df(
+                division_standings, tiebreaker_hierarchy
+            ).iloc[0]
+            division_winners = pd.concat(
+                [division_winners, division_winner.to_frame().T]
+            )
+
+        # Sort the division winners
+        sorted_division_winners = self._sort_standings_df(
+            division_winners, tiebreaker_hierarchy
+        )
+
+        # Then sort the rest of the teams
+        rest_of_field = standings_df.loc[
+            ~standings_df.index.isin(division_winners.index)
+        ]
+        sorted_rest_of_field = self._sort_standings_df(
+            rest_of_field, tiebreaker_hierarchy
+        )
+
+        # Combine all teams
+        sorted_standings = pd.concat(
+            [sorted_division_winners, sorted_rest_of_field],
+            axis=0,
+        )
+
+        return sorted_standings
 
     def top_scorer(self) -> Team:
         most_pf = sorted(self.teams, key=lambda x: x.points_for, reverse=True)
@@ -309,3 +414,167 @@ class League(BaseLeague):
                 messages.append(msg)
         return messages
 
+    def _build_division_record_dict(self) -> Dict:
+        """Create a DataFrame with each team's divisional record."""
+        # Get the list of teams
+        team_ids = [team.team_id for team in self.teams]
+
+        # Create a dictionary with each team's divisional record
+        div_outcomes = {
+            team.team_id: {"wins": 0, "divisional_games": 0} for team in self.teams
+        }
+
+        # Loop through each team's schedule and outcomes and build the dictionary
+        for team in self.teams:
+            for opp, outcome in zip(team.schedule[:week], team.outcomes[:week]):
+                if team.division_id == opp.division_id:
+                    if outcome == "W":
+                        div_outcomes[team.team_id]["wins"] += 1
+                    if outcome == "T":
+                        div_outcomes[team.team_id]["wins"] += 0.5
+
+                    div_outcomes[team.team_id]["divisional_games"] += 1
+
+        # Calculate the divisional record
+        div_record = {
+            team_id: (
+                div_outcomes[team_id]["wins"]
+                / max(div_outcomes[team_id]["divisional_games"], 1)
+            )
+            for team_id in team_ids
+        }
+
+        return div_record
+
+    def _build_h2h_df(self) -> pd.DataFrame:
+        """Create a dataframe that contains the head-to-head victories between each team in the league"""
+        # Get the list of teams
+        team_ids = [team.team_id for team in self.teams]
+
+        # Initialize the DataFrame
+        h2h_df = pd.DataFrame(index=team_ids, columns=team_ids).replace(np.nan, 0)
+
+        # Loop through each team
+        for team in self.teams:
+            # Get the team's schedule
+            schedule = team.schedule
+            outcomes = team.outcomes
+
+            # Loop through each week
+            for week, opp in enumerate(schedule):
+                # Update the DataFrame
+                if outcomes[week] == "W":
+                    h2h_df.loc[team.team_id, opp.team_id] += 1
+
+                if outcomes[week] == "T":
+                    h2h_df.loc[team.team_id, opp.team_id] += 0.5
+
+        return h2h_df
+
+    def _sort_by_win_pct(self, standings_df: pd.DataFrame) -> pd.DataFrame:
+        """Take a DataFrame of standings and sort it using the TOTAL_POINTS_SCORED tiebreaker"""
+        return standings_df.sort_values(by="win_pct", ascending=False)
+
+    def _sort_by_points_for(self, standings_df: pd.DataFrame) -> pd.DataFrame:
+        """Take a DataFrame of standings and sort it using the TOTAL_POINTS_SCORED tiebreaker"""
+        return standings_df.sort_values(by="points_for", ascending=False)
+
+    def _sort_by_division_record(self, standings_df: pd.DataFrame) -> pd.DataFrame:
+        division_records = build_division_record_df(self)
+        standings_df["division_record"] = standings_df.index.map(division_records)
+        return standings_df.sort_values(by="division_record", ascending=False)
+
+    def _sort_by_points_against(self, standings_df: pd.DataFrame) -> pd.DataFrame:
+        """Take a DataFrame of standings and sort it using the 3rd level tiebreaker"""
+        return standings_df.sort_values(by="points_against", ascending=True)
+
+    def _sort_by_coin_flip(self, standings_df: pd.DataFrame) -> pd.DataFrame:
+        standings_df["coin_flip"] = np.random.rand(len(standings_df))
+        return standings_df.sort_values(by="coin_flip", ascending=False)
+
+    def _sort_by_head_to_head(
+        self,
+        standings_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        """Take a DataFrame of standings and sort it using the H2H_RECORD tiebreaker"""
+        # If there is only one team, return the dataframe as-is
+        if len(standings_df) == 1:
+            return standings_df
+
+        # Filter the H2H DataFrame to only include the teams in question
+        team_ids = standings_df.index.tolist()
+        h2h_df = self._build_h2h_df().loc[team_ids, team_ids]
+
+        # If there are only two teams, sort descending by H2H wins
+        if len(h2h_df) == 2:
+            standings_df["h2h_wins"] = h2h_df.sum(axis=1)
+            return standings_df.sort_values(by="h2h_wins", ascending=False)
+
+        # If there are more than two teams...
+        if len(h2h_df) > 2:
+            # Check if the teams have all played each other an equal number of times
+            matchup_combos = list(combinations(team_ids, 2))
+            matchup_counts = [
+                h2h_df.loc[t1, t2] + h2h_df.loc[t2, t1] for t1, t2 in matchup_combos
+            ]
+            if len(set(matchup_counts)) == 1:
+                # All teams have played each other an equal number of times
+                # Sort the teams by total H2H wins against each other
+                standings_df["h2h_wins"] = h2h_df.sum(axis=1)
+                return standings_df.sort_values(by="h2h_wins", ascending=False)
+            else:
+                # All teams have not played each other an equal number of times
+                # This tiebreaker is invalid
+                standings_df["h2h_wins"] = 0
+                return standings_df
+
+    def _sort_standings_df(
+        self,
+        standings_df: pd.DataFrame,
+        tiebreaker_hierarchy: List[Tuple[Callable, str]],
+    ) -> pd.DataFrame:
+        """This recursive function sorts a standings DataFrame by the tiebreaker hierarchy.
+        It iterates through each tiebreaker, sorting any remaning ties by the next tiebreaker.
+
+        Args:
+            standings_df (pd.DataFrame): Standings DataFrame to sort
+            tiebreaker_hierarchy (List[Tuple[Callable, str]]): List of tiebreaker functions and columns to sort by
+
+        Returns:
+            pd.DataFrame: Sorted standings DataFrame
+        """
+        # If there are no more tiebreakers, return the standings DataFrame as-is
+        if not tiebreaker_hierarchy:
+            return standings_df
+
+        # If there is only one team to sort, return the standings DataFrame as-is
+        if len(standings_df) == 1:
+            return standings_df
+
+        # Get the tiebreaker function and column name to group by
+        tiebreaker_function = tiebreaker_hierarchy[0][0]
+        tiebreaker_col = tiebreaker_hierarchy[0][1]
+
+        # Apply the tiebreaker function to the standings DataFrame
+        standings_df = tiebreaker_function(standings_df)
+
+        # Loop through each remaining unique tiebreaker value to see if ties remain
+        sorted_standings = pd.DataFrame()
+        for val in sorted(standings_df[tiebreaker_col].unique(), reverse=True):
+            standings_subset = standings_df[standings_df[tiebreaker_col] == val]
+
+            # Sort all remaining teams with the next tiebreaker
+            sorted_subset = self._sort_standings_df(
+                standings_subset,
+                tiebreaker_hierarchy[1:],
+            )
+
+            # Append the sorted subset to the final sorted standings DataFrame
+            sorted_standings = pd.concat(
+                [
+                    sorted_standings,
+                    sorted_subset,
+                ]
+            )
+
+        return sorted_standings

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -116,7 +116,7 @@ class League(BaseLeague):
         standings = sorted(self.teams, key=lambda x: x.final_standing if x.final_standing != 0 else x.standing, reverse=False)
         return standings
 
-    def standings_weekly(self, week: int) -> pd.DataFrame:
+    def standings_weekly(self, week: int) -> List[Dict]:
         """This is the main function to get the standings for a given week.
 
         It controls the tiebreaker hierarchy and calls the recursive League()._sort_team_data_list function.
@@ -133,7 +133,7 @@ class League(BaseLeague):
             week (int): Week to get the standings for
 
         Returns:
-            pd.DataFrame: Sorted standings list
+            List[Dict]: Sorted standings list
         """
         # Get standings data for each team up to the given week
         list_of_team_data = []
@@ -157,6 +157,7 @@ class League(BaseLeague):
             )
             list_of_team_data.append(team_data)
 
+        # Identify the proper tiebreaker hierarchy
         if self.settings.playoff_seed_tie_rule == "TOTAL_POINTS_SCORED":
             tiebreaker_hierarchy = [
                 (self._sort_by_win_pct, "win_pct"),

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -161,6 +161,7 @@ class League(BaseLeague):
                     [team.schedule[w].scores[w] for w in range(week)]
                 ),
                 "schedule": team.schedule[:week],
+                "outcomes": team.outcomes[:week],
             }
             team_data["win_pct"] = (team_data["wins"] + team_data["ties"] / 2) / sum(
                 [1 for outcome in team.outcomes[:week] if outcome in ["W", "T", "L"]]

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -87,8 +87,15 @@ class LeagueTest(TestCase):
 
         league = League(self.league_id, self.season)
 
-        valid_week = league.standings_weekly(1)
-        self.assertEqual(valid_week[0].wins > valid_week[-1].wins, True)
+        week = 1
+        standings = league.standings_weekly(1)
+        best_team_after_week = sum(
+            [1 for outcome in standings[0].outcomes[:week] if outcome == "W"]
+        )
+        worst_team_after_week = sum(
+            [1 for outcome in standings[-1].outcomes[:week] if outcome == "W"]
+        )
+        self.assertEqual(best_team_after_week >= worst_team_after_week, True)
 
     @requests_mock.Mocker()
     def test_top_scorer(self, m):

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -255,12 +255,20 @@ class LeagueTest(TestCase):
                 sorted_list_of_team_data[i + 1]["points_for"],
             )
 
-        # Assert that sort_by_head_to_head is correct
+        # Assert that sort_by_head_to_head is correct - 2 teams
         sorted_list_of_team_data = sort_by_head_to_head(
-            [team for team in list_of_team_data if team["team_id"] in (1, 2)]
+            [team for team in week10_teams_data if team["team_id"] in (1, 2)]
+        )
+        self.assertEqual(sorted_list_of_team_data[0]["team_id"], 1)
+
+        # Assert that sort_by_head_to_head is correct - 3 teams
+        sorted_list_of_team_data = sort_by_head_to_head(
+            [team for team in week10_teams_data if team["team_id"] in (1, 2, 3)]
         )
         # Team 1 is undefeated vs team 2
         self.assertEqual(sorted_list_of_team_data[0]["team_id"], 1)
+        self.assertEqual(sorted_list_of_team_data[1]["team_id"], 3)
+        self.assertEqual(sorted_list_of_team_data[2]["team_id"], 2)
 
         # Assert that sort_by_division_record is correct
         sorted_list_of_team_data = sort_by_division_record(week10_teams_data)

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -87,15 +87,17 @@ class LeagueTest(TestCase):
 
         league = League(self.league_id, self.season)
 
-        week = 1
-        standings = league.standings_weekly(1)
-        best_team_after_week = sum(
-            [1 for outcome in standings[0].outcomes[:week] if outcome == "W"]
-        )
-        worst_team_after_week = sum(
-            [1 for outcome in standings[-1].outcomes[:week] if outcome == "W"]
-        )
-        self.assertEqual(best_team_after_week >= worst_team_after_week, True)
+        # Test various weeks
+        week1_standings = [team.team_id for team in league.standings_weekly(1)]
+        self.assertEqual(week1_standings, [3, 11, 2, 10, 7, 8, 4, 5, 9, 1])
+
+        week4_standings = [team.team_id for team in league.standings_weekly(4)]
+        self.assertEqual(week4_standings, [2, 7, 11, 4, 3, 9, 1, 8, 5, 10])
+
+        # # Does not work with the playoffs
+        # week13_standings = [team.team_id for team in league.standings_weekly(13)]
+        # final_standings = [team.team_id for team in league.standings()]
+        # self.assertEqual(week13_standings, final_standings)
 
     @requests_mock.Mocker()
     def test_top_scorer(self, m):

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -110,6 +110,31 @@ class LeagueTest(TestCase):
         # final_standings = [team.team_id for team in league.standings()]
         # self.assertEqual(week13_standings, final_standings)
 
+    def get_list_of_team_data(self, league: League, week: int):
+        list_of_team_data = []
+        for team in league.teams:
+            team_data = {
+                "team": team,
+                "team_id": team.team_id,
+                "division_id": team.division_id,
+                "wins": sum([1 for outcome in team.outcomes[:week] if outcome == "W"]),
+                "ties": sum([1 for outcome in team.outcomes[:week] if outcome == "T"]),
+                "losses": sum(
+                    [1 for outcome in team.outcomes[:week] if outcome == "L"]
+                ),
+                "points_for": sum(team.scores[:week]),
+                "points_against": sum(
+                    [team.schedule[w].scores[w] for w in range(week)]
+                ),
+                "schedule": team.schedule[:week],
+                "outcomes": team.outcomes[:week],
+            }
+            team_data["win_pct"] = (team_data["wins"] + team_data["ties"] / 2) / sum(
+                [1 for outcome in team.outcomes[:week] if outcome in ["W", "T", "L"]]
+            )
+            list_of_team_data.append(team_data)
+        return list_of_team_data
+
     @requests_mock.Mocker()
     def test_build_h2h_dict(self, m):
         self.mock_setUp(m)

--- a/tests/football/unit/test_league.py
+++ b/tests/football/unit/test_league.py
@@ -81,7 +81,16 @@ class LeagueTest(TestCase):
         standings = league.standings()
         self.assertEqual(standings[0].final_standing, 1)
 
-    @requests_mock.Mocker()        
+    @requests_mock.Mocker()
+    def test_standings_weekly(self, m):
+        self.mock_setUp(m)
+
+        league = League(self.league_id, self.season)
+
+        valid_week = league.standings_weekly(1)
+        self.assertEqual(valid_week[0].wins > valid_week[-1].wins, True)
+
+    @requests_mock.Mocker()
     def test_top_scorer(self, m):
         self.mock_setUp(m)
 


### PR DESCRIPTION
This PR is to replace [another attempt](https://github.com/cwendt94/espn-api/pull/513).  

The tiebreaking process is quite complicated, but this follows all tiebreaking levels, subject to a league's specific tiebreaker rules.