### PR TITLE
Edge case "None" owners fix

### DIFF
--- a/espn_api/base_league.py
+++ b/espn_api/base_league.py
@@ -59,7 +59,7 @@ class BaseLeague(ABC):
 
         for team in teams:
             roster = team_roster[team['id']]
-            owners = [member for member in members if member.get('id') == team.get('owners', [''])[0]]
+            owners = [member for member in members if member.get('id') == (team.get('owners') or [''])[0]]
             self.teams.append(TeamClass(team, roster=roster, schedule=schedule, year=seasonId, owners=owners, pro_schedule=pro_schedule))
 
         # sort by team ID


### PR DESCRIPTION
fixes #518 

Fixes edge case, where if team has the key 'owners' but its value is None or an empty list, this will raise an IndexError. It will now properly make an empty list with an indexable [0] element