### PR TITLE
Add slot positions from roster settings

### DIFF
--- a/espn_api/football/settings.py
+++ b/espn_api/football/settings.py
@@ -1,11 +1,14 @@
 from ..base_settings import BaseSettings
-from .constant import SETTINGS_SCORING_FORMAT_MAP
+from .constant import SETTINGS_SCORING_FORMAT_MAP, POSITION_MAP
 
 class Settings(BaseSettings):
     def __init__(self, data):
         super().__init__(data)
         self.scoring_format = []
         scoring_items = data['scoringSettings'].get('scoringItems', [])
+        lineup_slot_counts = data['rosterSettings'].get('lineupSlotCounts', {})
+        position_labels = list(POSITION_MAP.values())[:len(lineup_slot_counts)]
+        self.position_slot_counts = dict(zip(position_labels,list(lineup_slot_counts.values())))
 
         for scoring_item in scoring_items:
             stat_id = scoring_item['statId']


### PR DESCRIPTION
In the context of a **draft**, it's useful to know how many slots are available for each position.  Within the API, this information is available as part of the `mSettings` view:

```
// psuedo-JSON response
{
  .... 
  rosterSettings: {
    ... 
    lineupSlotCounts: {
        "0": 1, // maps to "QB" slot 
        "1": 0, // maps to "TQB" slot
        "2": 2, // maps to "RB" slot
        ... etc, goes all the way to slot 24
    }
 }
}
```

We can map each lineupSlotCount(s) to it's respective position and provide this information to the consumer:
```
from espn_api.football import League

league = League(...)
print(league.settings.position_slot_counts)

# outputs the following dict
# {'QB': 1, 'TQB': 0, 'RB': 2, 'RB/WR': 0, 'WR': 2, 'WR/TE': 0, 'TE': 1, 'OP': 0, 'DT': 0, 'DE': 0, 'LB': 0, 'DL': 0, 'CB': 0, 'S': 0, 'DB': 0, 'DP': 0, 'D/ST': 1, 'K': 1, 'P': 0, 'HC': 0, 'BE': 7, 'IR': 1, '': 0, 'RB/WR/TE': 1, 'ER': 0}
```


