### PR TITLE
fix: Add caching to speed up `BoxScore` loading

### DIFF
--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import random
 from typing import Callable, Dict, List, Tuple, Union
@@ -277,6 +278,7 @@ class League(BaseLeague):
 
         return matchups
 
+    @functools.cache
     def box_scores(self, week: int = None) -> List[BoxScore]:
         '''Returns list of box score for a given week\n
         Should only be used with most recent season'''

--- a/espn_api/football/league.py
+++ b/espn_api/football/league.py
@@ -278,7 +278,7 @@ class League(BaseLeague):
 
         return matchups
 
-    @functools.cache
+    @functools.lru_cache
     def box_scores(self, week: int = None) -> List[BoxScore]:
         '''Returns list of box score for a given week\n
         Should only be used with most recent season'''


### PR DESCRIPTION
A very small PR to make the repo a bit faster in one use case. The `.box_score()` method can take ~1.5s on average to load, making it very slow if your code iterates over this many times. Adding this cache makes it easier to work with and orders of magnitude faster.