### PR TITLE
Fix ties bug

### DIFF
--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -72,8 +72,6 @@ class Team(object):
     def _get_winner(self, winner: str, is_away: bool) -> str:
         if winner == 'UNDECIDED':
             return 'U'
-        elif winner == 'TIE':
-            return 'T'
         elif (is_away and winner == 'AWAY') or (not is_away and winner == 'HOME'):
             return 'W'
         else:

--- a/espn_api/football/team.py
+++ b/espn_api/football/team.py
@@ -72,6 +72,8 @@ class Team(object):
     def _get_winner(self, winner: str, is_away: bool) -> str:
         if winner == 'UNDECIDED':
             return 'U'
+        elif winner == 'TIE':
+            return 'T'
         elif (is_away and winner == 'AWAY') or (not is_away and winner == 'HOME'):
             return 'W'
         else:


### PR DESCRIPTION
When populating the Team.outcomes attribute, the logic only considers three outcomes: Undecided (games that haven't been completed yet), Win, and Loss.

Resovles Issue #566 