### PR TITLE
Basketball League Transactions

### DIFF
--- a/espn_api/basketball/constant.py
+++ b/espn_api/basketball/constant.py
@@ -137,6 +137,22 @@ ACTIVITY_MAP = {
     'TRADED': 244,
 }
 
+TRANSACTION_TYPES = {
+    'DRAFT',
+    'TRADE_ACCEPT',
+    'WAIVER',
+    'TRADE_VETO',
+    'FUTURE_ROSTER',
+    'ROSTER',
+    'RETRO_ROSTER',
+    'TRADE_PROPOSAL',
+    'TRADE_UPHOLD',
+    'FREEAGENT',
+    'TRADE_DECLINE',
+    'WAIVER_ERROR',
+    'TRADE_ERROR'
+}
+
 NINE_CAT_STATS = {
     '3PM',
     'AST',

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -6,10 +6,9 @@ from .team import Team
 from .player import Player
 from .matchup import Matchup
 from .box_score import get_box_scoring_type_class, BoxScore
-from .constant import PRO_TEAM_MAP
 from .activity import Activity
 from .transaction import Transaction
-from .constant import POSITION_MAP, ACTIVITY_MAP
+from .constant import POSITION_MAP, ACTIVITY_MAP, TRANSACTION_TYPES
 
 class League(BaseLeague):
     '''Creates a League instance for Public/Private ESPN league'''
@@ -105,14 +104,20 @@ class League(BaseLeague):
 
         return activity
 
-    def transactions(self, scoring_period: int = None) -> List[Transaction]:
+    def transactions(self, scoring_period: int = None, types: set[str] = {"FREEAGENT","WAIVER","WAIVER_ERROR"}) -> List[Transaction]:
         '''Returns a list of recent transactions'''
+        if not scoring_period:
+            scoring_period = self.scoringPeriodId
+
+        if types > TRANSACTION_TYPES:
+            raise Exception('Invalid transaction type')
+
         params = {
             'view': 'mTransactions2',
             'scoringPeriodId': scoring_period,
         }
 
-        filters = {"transactions":{"filterType":{"value":["FREEAGENT","WAIVER","WAIVER_ERROR"]}}}
+        filters = {"transactions":{"filterType":{"value":list(types)}}}
         headers = {'x-fantasy-filter': json.dumps(filters)}
 
         data = self.espn_request.league_get(params=params, headers=headers)

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Tuple, Union
+from typing import List, Set, Union
 
 from ..base_league import BaseLeague
 from .team import Team
@@ -104,7 +104,7 @@ class League(BaseLeague):
 
         return activity
 
-    def transactions(self, scoring_period: int = None, types: set[str] = {"FREEAGENT","WAIVER","WAIVER_ERROR"}) -> List[Transaction]:
+    def transactions(self, scoring_period: int = None, types: Set[str] = {"FREEAGENT","WAIVER","WAIVER_ERROR"}) -> List[Transaction]:
         '''Returns a list of recent transactions'''
         if not scoring_period:
             scoring_period = self.scoringPeriodId

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -8,6 +8,7 @@ from .matchup import Matchup
 from .box_score import get_box_scoring_type_class, BoxScore
 from .constant import PRO_TEAM_MAP
 from .activity import Activity
+from .transaction import Transaction
 from .constant import POSITION_MAP, ACTIVITY_MAP
 
 class League(BaseLeague):
@@ -103,6 +104,21 @@ class League(BaseLeague):
         activity = [Activity(topic, self.player_map, self.get_team_data, include_moved=include_moved) for topic in data]
 
         return activity
+
+    def transactions(self, scoring_period: int = None) -> List[Transaction]:
+        '''Returns a list of recent transactions'''
+        params = {
+            'view': 'mTransactions2',
+            'scoringPeriodId': scoring_period,
+        }
+
+        filters = {"transactions":{"filterType":{"value":["FREEAGENT","WAIVER","WAIVER_ERROR"]}}}
+        headers = {'x-fantasy-filter': json.dumps(filters)}
+
+        data = self.espn_request.league_get(params=params, headers=headers)
+        transactions = data['transactions']
+
+        return [Transaction(transaction, self.player_map, self.get_team_data) for transaction in transactions]
 
     def free_agents(self, week: int=None, size: int=50, position: str=None, position_id: int=None) -> List[Player]:
         '''Returns a List of Free Agents for a Given Week\n

--- a/espn_api/basketball/transaction.py
+++ b/espn_api/basketball/transaction.py
@@ -1,13 +1,11 @@
-from .transaction_item import TransactionItem
-
 class Transaction(object):
     def __init__(self, data, player_map, get_team_data):
         self.team = get_team_data(data['teamId'])
         self.type = data['type']
         self.status = data['status']
         self.scoring_period = data['scoringPeriodId']
-        self.date = data['processDate']
-        self.bid_amount = data['bidAmount']
+        self.date = data.get('processDate')
+        self.bid_amount = data.get('bidAmount')
         self.items = []
         for item in data['items']:
             self.items.append(TransactionItem(item, player_map))
@@ -15,3 +13,11 @@ class Transaction(object):
     def __repr__(self):
         items = ', '.join([str(item) for item in self.items])
         return f'Transaction({self.team.team_name} {self.type} {items})'
+
+class TransactionItem(object):
+    def __init__(self, data, player_map):
+        self.type = data['type']
+        self.player = player_map[data['playerId']]
+
+    def __repr__(self):
+        return f'{self.type} {self.player}'

--- a/espn_api/basketball/transaction.py
+++ b/espn_api/basketball/transaction.py
@@ -1,0 +1,17 @@
+from .transaction_item import TransactionItem
+
+class Transaction(object):
+    def __init__(self, data, player_map, get_team_data):
+        self.team = get_team_data(data['teamId'])
+        self.type = data['type']
+        self.status = data['status']
+        self.scoring_period = data['scoringPeriodId']
+        self.date = data['processDate']
+        self.bid_amount = data['bidAmount']
+        self.items = []
+        for item in data['items']:
+            self.items.append(TransactionItem(item, player_map))
+
+    def __repr__(self):
+        items = ', '.join([str(item) for item in self.items])
+        return f'Transaction({self.team.team_name} {self.type} {items})'

--- a/espn_api/basketball/transaction_item.py
+++ b/espn_api/basketball/transaction_item.py
@@ -1,7 +1,0 @@
-class TransactionItem(object):
-    def __init__(self, data, player_map):
-        self.type = data['type']
-        self.player = player_map[data['playerId']]
-
-    def __repr__(self):
-        return f'{self.type} {self.player}'

--- a/espn_api/basketball/transaction_item.py
+++ b/espn_api/basketball/transaction_item.py
@@ -1,0 +1,7 @@
+class TransactionItem(object):
+    def __init__(self, data, player_map):
+        self.type = data['type']
+        self.player = player_map[data['playerId']]
+
+    def __repr__(self):
+        return f'{self.type} {self.player}'


### PR DESCRIPTION
New method `League.transactions()` uses the `mTransactions2` view to fetch more detailed transaction data than is available through `recent_activity`.

I'm only fetching free agent and waiver transactions right now because that's the only data I have available to test with in my league, however trades and roster moves are also available. In my testing I got a surprisingly helpful error message that enumerated all available transaction types:

DRAFT, TRADE_ACCEPT, WAIVER, TRADE_VETO, FUTURE_ROSTER, ROSTER, RETRO_ROSTER, TRADE_PROPOSAL, TRADE_UPHOLD, FREEAGENT, TRADE_DECLINE, WAIVER_ERROR, TRADE_ERROR