### PR TITLE
Handle bye weeks in matchup string representation

### DIFF
--- a/espn_api/football/matchup.py
+++ b/espn_api/football/matchup.py
@@ -11,7 +11,11 @@ class Matchup(object):
         self.away_team: Team
 
     def __repr__(self):
-        return f'Matchup({self.home_team}, {self.away_team})'
+        if hasattr(self, 'away_team'):
+            return f'Matchup({self.home_team}, {self.away_team})'
+        else:
+            return f'Matchup({self.home_team}, N/A)'
+            
 
     def _fetch_matchup_info(self, data, team):
         '''Fetch info for matchup'''


### PR DESCRIPTION
If you print a matchup object where there is a bye week, it fails with an error because there is no away team.

This fix assumes that bye weeks will always have a "home team: