### PR TITLE
Basketball - Add player and team typehints

### DIFF
--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -11,6 +11,7 @@ from .transaction import Transaction
 from .constant import POSITION_MAP, ACTIVITY_MAP, TRANSACTION_TYPES
 
 class League(BaseLeague):
+    teams: Team
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, debug=debug)

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -11,7 +11,7 @@ from .transaction import Transaction
 from .constant import POSITION_MAP, ACTIVITY_MAP, TRANSACTION_TYPES
 
 class League(BaseLeague):
-    teams: list[Team]
+    teams: List[Team]
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, debug=debug)

--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -11,7 +11,7 @@ from .transaction import Transaction
 from .constant import POSITION_MAP, ACTIVITY_MAP, TRANSACTION_TYPES
 
 class League(BaseLeague):
-    teams: Team
+    teams: list[Team]
     '''Creates a League instance for Public/Private ESPN league'''
     def __init__(self, league_id: int, year: int, espn_s2=None, swid=None, fetch_league=True, debug=False):
         super().__init__(league_id=league_id, year=year, sport='nba', espn_s2=espn_s2, swid=swid, debug=debug)

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .player import Player
 from .matchup import Matchup
 from .constant import STATS_MAP
@@ -23,7 +25,7 @@ class Team(object):
         self.stats = None
         self.standing = data['playoffSeed']
         self.final_standing = data['rankCalculatedFinal']
-        self.roster: list[Player] = []
+        self.roster: List[Player] = []
         self.schedule = []
         
         if 'valuesByStat' in data:

--- a/espn_api/basketball/team.py
+++ b/espn_api/basketball/team.py
@@ -23,7 +23,7 @@ class Team(object):
         self.stats = None
         self.standing = data['playoffSeed']
         self.final_standing = data['rankCalculatedFinal']
-        self.roster = []
+        self.roster: list[Player] = []
         self.schedule = []
         
         if 'valuesByStat' in data:


### PR DESCRIPTION
Very small PR to just add two type hints to the League and Team objects for usability. Found myself very often having to jump into source code to use the objects instead of just relying on IDE type hints.

AFAIK this is backwards compatible to all python versions but if there are specific tests or something to be shown let me know.