### PR TITLE
Basketball add expected return date to player

### DIFF
--- a/espn_api/basketball/player.py
+++ b/espn_api/basketball/player.py
@@ -19,7 +19,7 @@ class Player(object):
         self.stats = {}
         self.schedule = {}
         expected_return_date = json_parsing(data, 'expectedReturnDate')
-        self.expectedReturnDate = datetime(*expected_return_date).date() if expected_return_date else None
+        self.expected_return_date = datetime(*expected_return_date).date() if expected_return_date else None
 
         if pro_team_schedule:
             pro_team_id = json_parsing(data, 'proTeamId')

--- a/espn_api/basketball/player.py
+++ b/espn_api/basketball/player.py
@@ -18,6 +18,8 @@ class Player(object):
         self.posRank = json_parsing(data, 'positionalRanking')
         self.stats = {}
         self.schedule = {}
+        expected_return_date = json_parsing(data, 'expectedReturnDate')
+        self.expectedReturnDate = datetime(*expected_return_date).date() if expected_return_date else None
 
         if pro_team_schedule:
             pro_team_id = json_parsing(data, 'proTeamId')


### PR DESCRIPTION
Small commit to add expected return date (from injury) to the player class. It returns a datetime date.

Example:
league.player_info(name="Jalen Johnson").expectedReturnDate)

Return:
2025-01-30

Alternatively if you prefer to keep it simple we could do it in one line:
self.expectedReturnDate = json_parsing(data, 'expectedReturnDate')

And then the same code returns:
[2025, 1, 30]

Just thought it might be nice to return in datetime format but I'm good with it either way.