### PR TITLE
bugfix/Fix multiple pro schedule requests

### DIFF
--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -47,8 +47,8 @@ class League(BaseLeague):
 
     def _fetch_teams(self, data):
         '''Fetch teams in league'''
-        pro_schedule = self._get_all_pro_schedule()
-        super()._fetch_teams(data, TeamClass=Team, pro_schedule=pro_schedule)
+        self.pro_schedule = self._get_all_pro_schedule()
+        super()._fetch_teams(data, TeamClass=Team, pro_schedule=self.pro_schedule)
 
         # replace opponentIds in schedule with team instances
         for team in self.teams:
@@ -184,8 +184,7 @@ class League(BaseLeague):
         data = self.espn_request.league_get(params=params, headers=headers)
 
         schedule = data['schedule']
-        pro_schedule = self._get_all_pro_schedule()
-        box_data = [self.BoxScoreClass(matchup, pro_schedule, matchup_total, self.year, scoring_id) for matchup in schedule]
+        box_data = [self.BoxScoreClass(matchup, self.pro_schedule, matchup_total, self.year, scoring_id) for matchup in schedule]
 
         for team in self.teams:
             for matchup in box_data:
@@ -207,9 +206,7 @@ class League(BaseLeague):
 
         data = self.espn_request.get_player_card(playerId, self.finalScoringPeriod)
 
-        pro_schedule = self._get_all_pro_schedule()
-
         if len(data['players']) == 1:
-            return Player(data['players'][0], self.year, pro_schedule)
+            return Player(data['players'][0], self.year, self.pro_schedule)
         if len(data['players']) > 1:
-            return [Player(player, self.year, pro_schedule) for player in data['players']]
+            return [Player(player, self.year, self.pro_schedule) for player in data['players']]


### PR DESCRIPTION
When a league is initialized, a get_pro_schedule espn request is done. It's not stored though so when league.box_scores or league.player_info is called, it re-calls the pro schedule request. 

This can be fixed by changing this line in the _fetch_teams function from:
pro_schedule = self._get_all_pro_schedule()
to:
self.pro_schedule = self._get_all_pro_schedule()

and then using self.pro_schedule in the other league functions box_Scores and player_info.

Take this basic program:

league = espn_api.basketball.League(...)
player = league.player_info(playerId=[4701230])
box = league.box_scores()

Currently this does the following api requests:

1. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': ['mTeam', 'mRoster', 'mMatchup', 'mSettings', 'mStandings']} headers: None
2. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/players params: {'view': 'players_wl'} headers: {'x-fantasy-filter': '{"filterActive": {"value": true}}'}
3. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025 params: {'view': 'proTeamSchedules_wl'} headers: None
4. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': 'mDraftDetail'} headers: None
5. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': 'kona_playercard'} headers: {'x-fantasy-filter': '{"players": {"filterIds": {"value": [4701230]}, "filterStatsForTopScoringPeriodIds": {"value": 146, "additionalValue": ["002025", "102025"]}}}'}
6. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025 params: {'view': 'proTeamSchedules_wl'} headers: None
7. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': ['mMatchupScore', 'mScoreboard'], 'scoringPeriodId': 103} headers: {'x-fantasy-filter': '{"schedule": {"filterMatchupPeriodIds": {"value": [15]}}}'}
8. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025 params: {'view': 'proTeamSchedules_wl'} headers: None

Note the 3 pro schedule requests, #s 3, 6, 8. 

With this fix the same program only does the pro schedule request once, when the league is initialized:

1. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': ['mTeam', 'mRoster', 'mMatchup', 'mSettings', 'mStandings']} headers: None
2. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/players params: {'view': 'players_wl'} headers: {'x-fantasy-filter': '{"filterActive": {"value": true}}'}
3. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025 params: {'view': 'proTeamSchedules_wl'} headers: None
4. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': 'mDraftDetail'} headers: None
5. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': 'kona_playercard'} headers: {'x-fantasy-filter': '{"players": {"filterIds": {"value": [4701230]}, "filterStatsForTopScoringPeriodIds": {"value": 146, "additionalValue": ["002025", "102025"]}}}'}
6. ESPN API Request: url: https://lm-api-reads.fantasy.espn.com/apis/v3/games/fba/seasons/2025/segments/0/leagues/64732 params: {'view': ['mMatchupScore', 'mScoreboard'], 'scoringPeriodId': 103} headers: {'x-fantasy-filter': '{"schedule": {"filterMatchupPeriodIds": {"value": [15]}}}'}

