### PR TITLE
Basketball Add Player News

### DIFF
--- a/espn_api/basketball/league.py
+++ b/espn_api/basketball/league.py
@@ -195,7 +195,7 @@ class League(BaseLeague):
                     matchup.away_team = team
         return box_data
 
-    def player_info(self, name: str = None, playerId: Union[int, list] = None) -> Union[Player, List[Player]]:
+    def player_info(self, name: str = None, playerId: Union[int, list] = None, include_news = False) -> Union[Player, List[Player]]:
         ''' Returns Player class if name found '''
 
         if name:
@@ -209,7 +209,12 @@ class League(BaseLeague):
 
         pro_schedule = self._get_all_pro_schedule()
 
+        if include_news:
+            news = {}
+            for id in playerId:
+                news[id] = self.espn_request.get_player_news(id)
+
         if len(data['players']) == 1:
-            return Player(data['players'][0], self.year, pro_schedule)
+            return Player(data['players'][0], self.year, pro_schedule, news=news.get(playerId[0], []) if include_news else None)
         if len(data['players']) > 1:
-            return [Player(player, self.year, pro_schedule) for player in data['players']]
+            return [Player(player, self.year, pro_schedule, news=news.get(player['id'], []) if include_news else None) for player in data['players']]

--- a/espn_api/basketball/player.py
+++ b/espn_api/basketball/player.py
@@ -5,7 +5,7 @@ from functools import cached_property
 
 class Player(object):
     '''Player are part of team'''
-    def __init__(self, data, year, pro_team_schedule = None):
+    def __init__(self, data, year, pro_team_schedule = None, news = None):
         self.name = json_parsing(data, 'fullName')
         self.playerId = json_parsing(data, 'id')
         self.year = year
@@ -18,6 +18,7 @@ class Player(object):
         self.posRank = json_parsing(data, 'positionalRanking')
         self.stats = {}
         self.schedule = {}
+        self.news = {}
 
         if pro_team_schedule:
             pro_team_id = json_parsing(data, 'proTeamId')
@@ -27,7 +28,16 @@ class Player(object):
                 team = game['awayProTeamId'] if game['awayProTeamId'] != pro_team_id else game['homeProTeamId']
                 self.schedule[key] = { 'team': PRO_TEAM_MAP[team], 'date': datetime.fromtimestamp(game['date']/1000.0) }
 
-
+        if news:
+            news_feed = news.get("news", {}).get("feed", [])
+            self.news = [
+                {
+                    "published": item.get("published", ""),
+                    "headline": item.get("headline", ""),
+                    "story": item.get("story", "")
+                }
+                for item in news_feed
+            ]
 
         # add available stats
 

--- a/espn_api/requests/constant.py
+++ b/espn_api/requests/constant.py
@@ -1,4 +1,5 @@
 FANTASY_BASE_ENDPOINT = 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/'
+NEWS_BASE_ENDPOINT = 'https://site.api.espn.com/apis/fantasy/v3/games/'
 FANTASY_SPORTS = {
     'nfl' : 'ffl',
     'nba' : 'fba',

--- a/espn_api/requests/espn_requests.py
+++ b/espn_api/requests/espn_requests.py
@@ -1,6 +1,6 @@
 import requests
 import json
-from .constant import FANTASY_BASE_ENDPOINT, FANTASY_SPORTS
+from .constant import FANTASY_BASE_ENDPOINT, NEWS_BASE_ENDPOINT, FANTASY_SPORTS
 from ..utils.logger import Logger
 from typing import List
 
@@ -24,6 +24,7 @@ class EspnFantasyRequests(object):
         self.year = year
         self.league_id = league_id
         self.ENDPOINT = FANTASY_BASE_ENDPOINT + FANTASY_SPORTS[sport] + '/seasons/' + str(self.year)
+        self.NEWS_ENDPOINT = NEWS_BASE_ENDPOINT + FANTASY_SPORTS[sport] + '/news/' + 'players'
         self.cookies = cookies
         self.logger = logger
 
@@ -82,6 +83,14 @@ class EspnFantasyRequests(object):
         endpoint = self.ENDPOINT + extend
         r = requests.get(endpoint, params=params, headers=headers, cookies=self.cookies)
         self.checkRequestStatus(r.status_code)
+
+        if self.logger:
+            self.logger.log_request(endpoint=endpoint, params=params, headers=headers, response=r.json())
+        return r.json()
+        
+    def news_get(self, params: dict = None, headers: dict = None, extend: str = ''):
+        endpoint = self.NEWS_ENDPOINT + extend
+        r = requests.get(endpoint, params=params, headers=headers, cookies=self.cookies)
 
         if self.logger:
             self.logger.log_request(endpoint=endpoint, params=params, headers=headers, response=r.json())
@@ -150,6 +159,12 @@ class EspnFantasyRequests(object):
         headers = {'x-fantasy-filter': json.dumps(filters)}
 
         data = self.league_get(params=params, headers=headers)
+        return data
+
+    def get_player_news(self, playerId):
+        '''Gets the player news'''
+        params = {'playerId': playerId}
+        data = self.news_get(params=params)
         return data
 
     # Username and password no longer works using their API without using google recaptcha


### PR DESCRIPTION
This adds player news to the player_info function in league.py. Player is then initialized with self.news, which is a dictionary with the date the news was published, the headline, and the story. It works with a single payer or with a list of player Ids. For example this program:

players = league.player_info(playerId=[4701230, 4277956], include_news=True)

for player in players:
       print(player.news)
       
returns this:
[{'published': '2025-01-29T15:41:35Z', 'headline': 'Johnson was diagnosed Wednesday with a torn labrum in his left shoulder and will miss the rest of the season, league sources tell NBA reporter Chris Haynes.', 'story': "After breaking out in his first season as a full-time starter in 2023-24, Johnson had taken another step forward in 2024-25 ...
[{'published': '2025-01-31T13:28:53Z', 'headline': "Poole ended with 19 points (5-15 FG, 3-10 3Pt, 6-7 FT), five rebounds and two assists in 25 minutes during Thursday's 134-96 loss to the Lakers.", 'story': "Poole did all he could to help boost Washington in Thursday's contest, leading all Wizards players in scoring and threes ...

Unfortunately there is no way to return multiple player's news with a single api request. So each of these is a seperate api request:

ESPN API Request: url: https://site.api.espn.com/apis/fantasy/v3/games/fba/news/players params: {'playerId': 4701230} headers: None
ESPN API Request: url: https://site.api.espn.com/apis/fantasy/v3/games/fba/news/players params: {'playerId': 4277956} headers: None

This is why I made include_news an optional argument with a default value of False. So that programs that call player_info with a long list of playerIds won't be making a lot of additional api requests unless the news is needed.




