### PR TITLE
Add transactions to football

### DIFF
--- a/espn_api/football/constant.py
+++ b/espn_api/football/constant.py
@@ -505,3 +505,19 @@ SETTINGS_SCORING_FORMAT_MAP = {
     233: { 'abbr': 'FGAY50', 'label': 'Every 50 FG Attempt yards' },
     234: { 'abbr': 'FGAY100', 'label': 'Every 100 FG Attempt yards' }
 }
+
+TRANSACTION_TYPES = {
+    'DRAFT',
+    'TRADE_ACCEPT',
+    'WAIVER',
+    'TRADE_VETO',
+    'FUTURE_ROSTER',
+    'ROSTER',
+    'RETRO_ROSTER',
+    'TRADE_PROPOSAL',
+    'TRADE_UPHOLD',
+    'FREEAGENT',
+    'TRADE_DECLINE',
+    'WAIVER_ERROR',
+    'TRADE_ERROR'
+}

--- a/espn_api/football/transaction.py
+++ b/espn_api/football/transaction.py
@@ -1,0 +1,23 @@
+class Transaction(object):
+    def __init__(self, data, player_map, get_team_data):
+        self.team = get_team_data(data['teamId'])
+        self.type = data['type']
+        self.status = data['status']
+        self.scoring_period = data['scoringPeriodId']
+        self.date = data.get('processDate')
+        self.bid_amount = data.get('bidAmount')
+        self.items = []
+        for item in data['items']:
+            self.items.append(TransactionItem(item, player_map))
+
+    def __repr__(self):
+        items = ', '.join([str(item) for item in self.items])
+        return f'Transaction({self.team.team_name} {self.type} {items})'
+
+class TransactionItem(object):
+    def __init__(self, data, player_map):
+        self.type = data['type']
+        self.player = player_map[data['playerId']]
+
+    def __repr__(self):
+        return f'{self.type} {self.player}'


### PR DESCRIPTION
Fixes #576 

Used same implementation that exists within Basketball for Football to grab transactions without needing ESPN_S2 and SWID.

Tested sucessfully 

```
from espn_api.football.league import League

league_id=164483
year=2024
league = League(league_id, year)
transactions = league.transactions(scoring_period=16)
for transaction in transactions:
    print(transaction)
```