### PR TITLE
fix(BoxPlayer): use a fallback for projected_points

### DIFF
--- a/espn_api/football/box_player.py
+++ b/espn_api/football/box_player.py
@@ -30,9 +30,11 @@ class BoxPlayer(Player):
 
         stats = self.stats.get(week, {})
         self.points = stats.get('points', 0)
-        self.points_breakdown = stats.get('breakdown', 0)
+        self.breakdown = stats.get('breakdown', {})
+        self.points_breakdown = stats.get('points_breakdown', {})
         self.projected_points = stats.get('projected_points', 0)
-        self.projected_breakdown = stats.get('projected_breakdown', 0)
+        self.projected_breakdown = stats.get('projected_breakdown', {})
+        self.projected_points_breakdown = stats.get('projected_points_breakdown', {})
 
         # Backup projected_points extraction from raw data if not available from stats
         if self.projected_points == 0:


### PR DESCRIPTION
I dug through the JSON results for espn api pulls and found out the projected points is provided for previous years but it's hidden in a second list entry. I added a fallback way to find the projected points for a backup player. I tested this locally without issues. 

Let me know your thoughts.