### PR TITLE
Fix date not being added to Transactions that aren't of type WAIVER

### DIFF
--- a/espn_api/football/transaction.py
+++ b/espn_api/football/transaction.py
@@ -5,6 +5,8 @@ class Transaction(object):
         self.status = data['status']
         self.scoring_period = data['scoringPeriodId']
         self.date = data.get('processDate')
+        if not self.date:
+            self.date = data.get('proposedDate')
         self.bid_amount = data.get('bidAmount')
         self.items = []
         for item in data['items']:


### PR DESCRIPTION
Currently the Transaction class adds it's member `date` variable by looking for the "processDate" key. However, the API does not return "processDate" for transactions that are not of type "WAIVER" (probably because transactions that don't go through the waiver process are assumed to process immediately). This pull request changes the behavior of the Transaction class to set the `date` member variable with the "proposedDate" when "processDate" does not exist in the received data.