### PR TITLE
Football - add/expose Point Breakdowns on Player/BoxPlayer

### DIFF
--- a/espn_api/football/box_player.py
+++ b/espn_api/football/box_player.py
@@ -30,9 +30,11 @@ class BoxPlayer(Player):
 
         stats = self.stats.get(week, {})
         self.points = stats.get('points', 0)
-        self.points_breakdown = stats.get('breakdown', 0)
+        self.breakdown = stats.get('breakdown', {})
+        self.points_breakdown = stats.get('points_breakdown', {})
         self.projected_points = stats.get('projected_points', 0)
-        self.projected_breakdown = stats.get('projected_breakdown', 0)
+        self.projected_breakdown = stats.get('projected_breakdown', {})
+        self.projected_points_breakdown = stats.get('projected_points_breakdown', {})
 
     def __repr__(self):
         return f'Player({self.name}, points:{self.points}, projected:{self.projected_points})'

--- a/espn_api/football/player.py
+++ b/espn_api/football/player.py
@@ -43,19 +43,26 @@ class Player(object):
         for stats in player_stats:
             if stats.get('seasonId') != year or stats.get('statSplitTypeId') == 2:
                 continue
-            stats_breakdown = stats.get('stats') or stats.get('appliedStats', {})
+
+            # real game stats (number of yards, number of passes, etc)- PLAYER_MAP may not be quite correct
+            stats_breakdown = stats.get('stats', {})
             breakdown = {PLAYER_STATS_MAP.get(int(k), k):v for (k,v) in stats_breakdown.items()}
+            # fantasy stats (points per td, ppr, points per yard bucket)
+            applied_stats = stats.get('appliedStats', {})
+            points_breakdown = {PLAYER_STATS_MAP.get(int(k), k):v for (k,v) in applied_stats.items()}
+
             points = round(stats.get('appliedTotal', 0), 2)
-            avg_points =  round(stats.get('appliedAverage', 0), 2)
+            avg_points = round(stats.get('appliedAverage', 0), 2)
             scoring_period = stats.get('scoringPeriodId')
             stat_source = stats.get('statSourceId')
-            (points_type, breakdown_type, avg_type) = ('points', 'breakdown', 'avg_points') if stat_source == 0 else ('projected_points', 'projected_breakdown', 'projected_avg_points')
+            (points_type, breakdown_type, points_breakdown_type, avg_type) = ('points', 'breakdown', 'points_breakdown', 'avg_points') if stat_source == 0 else ('projected_points', 'projected_breakdown', 'projected_points_breakdown', 'projected_avg_points')
             if self.stats.get(scoring_period):
                 self.stats[scoring_period][points_type] = points
                 self.stats[scoring_period][breakdown_type] = breakdown
+                self.stats[scoring_period][points_breakdown_type] = points_breakdown
                 self.stats[scoring_period][avg_type] = avg_points
             else:
-                self.stats[scoring_period] = {points_type: points, breakdown_type: breakdown, avg_type: avg_points}
+                self.stats[scoring_period] = {points_type: points, breakdown_type: breakdown, points_breakdown_type: points_breakdown, avg_type: avg_points}
             if not stat_source:
                 if not self.stats[scoring_period][breakdown_type]:
                     self.active_status = 'inactive'

--- a/tests/football/integration/test_league.py
+++ b/tests/football/integration/test_league.py
@@ -45,6 +45,21 @@ class LeagueTest(TestCase):
         self.assertEqual(repr(box_scores[1]), 'Box Score(Team(TEAM BERRY) at Team(TEAM HOLLAND))')
         self.assertEqual(box_scores[0].is_playoff, False)
 
+        player = box_scores[1].away_lineup[1]
+        self.assertTrue(hasattr(player, 'breakdown'))
+        self.assertTrue(hasattr(player, 'points_breakdown'))
+        self.assertNotEqual(player.breakdown, {})
+        self.assertNotEqual(player.points_breakdown, {})
+
+        self.assertEqual(player.breakdown['receivingTouchdowns'], 1.0)
+        self.assertEqual(player.points_breakdown['receivingTouchdowns'], 6.0)
+        self.assertEqual(player.projected_breakdown['receivingTouchdowns'], 0.637185906)
+        self.assertEqual(player.projected_points_breakdown['receivingTouchdowns'], 3.823115436)
+
+
+
+
+
         box_scores = league.box_scores()
         self.assertEqual(box_scores[0].is_playoff, True)
 


### PR DESCRIPTION
problem: Currently you can access BoxPlayer.stats[<week>].breakdown and projected_breakdown , but that's awkward and they are the real-world stats (# of yards, # of attempts) not fantasy stats (ppr, points per yardage bucket). The points breakdown also were not accessible via Player.

fix: add points_breakdown and projected_points_breakdown to Player.stats; make breakdown, points_breakdown, projected_breakdown, projected_points_breakdown top level attributes on BoxPlayer. Would have like to just make BoxPlayer.stats = Player.stats<week>, but don't want to break backwards compatibility.

