### PR TITLE
Included a method of installing and running tests for python >=3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__
 .env
 *~
 venv/
+.venv/
 .coverage
 build
 dist

--- a/README.md
+++ b/README.md
@@ -9,16 +9,44 @@ Please feel free to make suggestions, bug reports, and pull request for features
 This package was inspired and based off of [rbarton65/espnff](https://github.com/rbarton65/espnff).
 
 ## Installing
-With Git:
+### Note
+The difference in setup.py and requirements is in the test packages. If you are in python version >=3.9 then please use the requirements and pytest as nosetests is deprecated.
+
+With Git & Setup.py (Not recommended for Python >=3.9):
 ```
 git clone https://github.com/cwendt94/espn-api
 cd espn-api
 python3 setup.py install
 ```
+
+with Git and Requirements.txt (Recommended for python >=3.9)
+```
+git clone https://github.com/cwendt94/espn-api
+cd espn-api
+python -m venv myenv
+myenv\Scripts\activate.bat
+pip install -r requirementsV2.txt
+```
+
 With pip:
 ```
 pip install espn_api
 ```
+
+
+### Run Tests
+with nosetests (Not recommended for Python >=3.9):
+```
+python3 setup.py nosetests
+```
+
+with pytest (Recommended for Python >=3.9)
+```
+pytest
+```
+
+
+
 
 ## Usage
 ### [For Getting Started and API details head over to the Wiki!](https://github.com/cwendt94/espn-api/wiki)
@@ -35,10 +63,7 @@ from espn_api.baseball import League
 league = League(league_id=222, year=2019)
 ```
 
-### Run Tests
-```
-python3 setup.py nosetests
-```
+
 ## [Discussions](https://github.com/cwendt94/espn-api/discussions) (new)
 If you have any questions about the package, ESPN API data, or want to talk about a feature please start a [discussion](https://github.com/cwendt94/espn-api/discussions)! 
 

--- a/requirementsV2.txt
+++ b/requirementsV2.txt
@@ -1,0 +1,14 @@
+certifi==2025.10.5
+charset-normalizer==3.4.3
+colorama==0.4.6
+espn_api==0.45.1
+idna==3.10
+iniconfig==2.1.0
+packaging==25.0
+pluggy==1.6.0
+Pygments==2.19.2
+pytest==8.4.2
+requests==2.32.5
+requests-mock==1.12.1
+setuptools==80.9.0
+urllib3==2.2.3


### PR DESCRIPTION
In this small update, i added the ability to run tests on python versions >=3.9 as nosetests has not been maintained in a long time,  and pytest is one of the more popular approaches to setup simple unit tests.

The implementation simply installs dependencies via pip and a requirements file to a virtual env (or global if they really want to but not recommended), then the user would simply need to run pytests in their terminal and the module will find all documented tests in the project. 