### PR TITLE
Add 2026 WNBA expansion teams (Toronto Tempo, Portland Fire) to PRO_TEAM_MAP

### DIFF
--- a/espn_api/wbasketball/constant.py
+++ b/espn_api/wbasketball/constant.py
@@ -34,6 +34,8 @@ PRO_TEAM_MAP = {
     19: 'Chi',
     20: 'Atl',
     129689: 'GSV',
+    131935: 'Tor',
+    132052: 'Por',
 }
 
 STATS_MAP = {


### PR DESCRIPTION
## Summary

Adds the two new 2026 WNBA franchises to `espn_api/wbasketball/constant.py::PRO_TEAM_MAP`:

- `131935: 'Tor'` — Toronto Tempo
- `132052: 'Por'` — Portland Fire

## Why

Without these entries, instantiating `League(year=2026, ...)` raises `KeyError` as soon as any roster contains a player on either franchise, because `wbasketball/player.py:13` does an unguarded lookup:

```python
self.proTeam = PRO_TEAM_MAP[json_parsing(data, 'proTeamId')]
```

Traceback:
```
File ".../espn_api/wbasketball/player.py", line 13, in __init__
    self.proTeam = PRO_TEAM_MAP[json_parsing(data, 'proTeamId')]
KeyError: 131935
```

This blocks all 2026 league access for any league with at least one Tempo or Fire player rostered (which in practice is most of them).

## Repro

```python
from espn_api.wbasketball import League
League(league_id=<id>, year=2026, espn_s2=..., swid=...)
# KeyError: 131935  (or 132052)
```

The fix follows the existing precedent for Golden State Valkyries (`129689: 'GSV'`), which was added to the same map last season.

## Test plan

- [x] Verified IDs by hitting `https://lm-api-reads.fantasy.espn.com/apis/v3/games/wfba/seasons/2026/segments/0/leagues/{id}?view=mTeam&view=mRoster` and inspecting `proTeamId` values for known Tempo/Fire players.
- [x] Confirmed `League(year=2026, ...)` no longer raises and returns full rosters across multiple leagues after applying the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)